### PR TITLE
new package: python-numpy

### DIFF
--- a/disabled-tur/openblas/build.sh
+++ b/disabled-tur/openblas/build.sh
@@ -1,0 +1,103 @@
+TERMUX_PKG_HOMEPAGE=http://www.openblas.net/
+TERMUX_PKG_DESCRIPTION="An optimized BLAS library"
+TERMUX_PKG_LICENSE="BSD 3-Clause"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=0.3.20
+TERMUX_PKG_SRCURL=https://github.com/xianyi/OpenBLAS.git
+TERMUX_PKG_FORCE_CMAKE=true
+
+if $TERMUX_ON_DEVICE_BUILD; then
+	termux_error_exit "Package '$TERMUX_PKG_NAME' is not available for on-device builds."
+fi
+
+# XXX: This step will setup an old NDK toolchain (r13b) containing gcc and
+# XXX: gfortran. If NDK toolchain with llvm contains fortran compiler, this
+# XXX: step may be unnecessary.
+_setup_fortran_toolchain_r13b() {
+	mkdir -p $TERMUX_COMMON_CACHEDIR/android-gfortran/r13b
+	local _NDK_ARCHIVE_FILE=$TERMUX_COMMON_CACHEDIR/android-gfortran/android-ndk-r13b-linux-x86_64.zip
+	local _NDK_URL=https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
+	local _NDK_SHA256=3524d7f8fca6dc0d8e7073a7ab7f76888780a22841a6641927123146c3ffd29c
+	local _NDK_GF_ARCH
+	local _NDK_GF_SHA256
+	if [ "$TERMUX_ARCH" == "aarch64" ]; then
+		_NDK_GF_ARCH="arm64"
+		_NDK_GF_SHA256=8810eb94682bff79d56800713a1845761e6f6636ab6d13ee1968d5b36834d60b
+		_NDK_GF_TOOLCHAIN_NAME="aarch64-linux-android-4.9"
+	elif [ "$TERMUX_ARCH" == "arm" ]; then
+		_NDK_GF_ARCH="arm"
+		_NDK_GF_SHA256=82d9f8e6c6c08d6e630dd43780526b371076fab489b5b7244ceba7702630121a
+		_NDK_GF_TOOLCHAIN_NAME="arm-linux-androideabi-4.9"
+	elif [ "$TERMUX_ARCH" == "x86_64" ]; then
+		_NDK_GF_ARCH="x86_64"
+		_NDK_GF_SHA256=7d897a05c28e16f0c357c1be5ad1ddee173882a5056506d5bfc6c84e94387976
+		_NDK_GF_TOOLCHAIN_NAME="x86_64-4.9"
+	elif [ "$TERMUX_ARCH" == "i686" ]; then
+		_NDK_GF_ARCH="x86"
+		_NDK_GF_SHA256=50e27874d965f0ae18973e99e2f5de35eef74d19bc478d3f6649fa3ed411e84a
+		_NDK_GF_TOOLCHAIN_NAME="x86-4.9"
+	fi
+	local _NDK_GF_FILE=$TERMUX_COMMON_CACHEDIR/android-gfortran/r13b/gcc-$_NDK_GF_ARCH-linux-x86_64.tar.bz2
+	local _NDK_GF_URL=https://github.com/buffer51/android-gfortran/releases/download/r13b/gcc-$_NDK_GF_ARCH-linux-x86_64.tar.bz2
+	local _NDK_TOOLCHAIN_TARGET=$TERMUX_PKG_TMPDIR/android-ndk-r13b/toolchains/$_NDK_GF_TOOLCHAIN_NAME/prebuilt/linux-x86_64
+	termux_download $_NDK_URL $_NDK_ARCHIVE_FILE $_NDK_SHA256
+	unzip -d $TERMUX_PKG_TMPDIR/ $_NDK_ARCHIVE_FILE > /dev/null 2>&1
+	termux_download $_NDK_GF_URL $_NDK_GF_FILE $_NDK_GF_SHA256
+	tar -jxf $_NDK_GF_FILE -C $TERMUX_PKG_TMPDIR/
+	rm -rf $_NDK_TOOLCHAIN_TARGET
+	mv $TERMUX_PKG_TMPDIR/$_NDK_GF_TOOLCHAIN_NAME $_NDK_TOOLCHAIN_TARGET
+	GFORTRAN_TOOLCHAIN=$TERMUX_PKG_TMPDIR/ndk-$TERMUX_ARCH-with-gfortran
+	python $TERMUX_PKG_TMPDIR/android-ndk-r13b/build/tools/make_standalone_toolchain.py \
+					--arch $_NDK_GF_ARCH --api $TERMUX_PKG_API_LEVEL --install-dir $GFORTRAN_TOOLCHAIN
+	TERMUX_STANDALONE_TOOLCHAIN="$GFORTRAN_TOOLCHAIN"
+}
+
+termux_step_pre_configure() {
+	# XXX: libncurses5 is used by `clang38`.
+	# XXX: So should TUR use a custom builder image?
+	env -i PATH="$PATH" sudo apt update
+	env -i PATH="$PATH" sudo apt install -y libncurses5
+
+	_setup_fortran_toolchain_r13b
+
+	CXXFLAGS=""
+	CFLAGS=""
+	LDFLAGS=""
+
+	local CROSS_PREFIX=$TERMUX_ARCH-linux-android
+
+	if [ "$TERMUX_ARCH" == "arm" ]; then
+		CROSS_PREFIX=arm-linux-androideabi
+	elif [ "$TERMUX_ARCH" == "x86_64" ] || [ "$TERMUX_ARCH" == "i686" ]; then
+		# XXX: CORE2 seems too old. So which target should be set for openblas?
+		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DTARGET=CORE2"
+	fi
+
+	# Backup these environment variables, since they are used by the building system.
+	_OLD_AR="$AR"
+	_OLD_STRIP="$STRIP"
+	_OLD_PATH="$PATH"
+
+	export AR=$CROSS_PREFIX-ar
+	export AS=$CROSS_PREFIX-as
+	export LD=$CROSS_PREFIX-ld
+	export NM=$CROSS_PREFIX-nm
+	export CC=$CROSS_PREFIX-gcc
+	export FC=$CROSS_PREFIX-gfortran
+	export CXX=$CROSS_PREFIX-g++
+	export CPP=$CROSS_PREFIX-cpp
+	export CXXCPP=$CROSS_PREFIX-cpp
+	export STRIP=$CROSS_PREFIX-strip
+	export RANLIB=$CROSS_PREFIX-ranlib
+	export STRINGS=$CROSS_PREFIX-strings
+	export PATH="$TERMUX_STANDALONE_TOOLCHAIN/bin:$PATH"
+
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON"
+}
+
+termux_step_post_make_install() {
+	# Recover these environment variables.
+	AR="$_OLD_AR"
+	STRIP="$_OLD_STRIP"
+	PATH="$_OLD_PATH"
+}

--- a/disabled-tur/python-scipy/build.sh
+++ b/disabled-tur/python-scipy/build.sh
@@ -1,0 +1,190 @@
+TERMUX_PKG_HOMEPAGE=https://scipy.org/
+TERMUX_PKG_DESCRIPTION="Fundamental algorithms for scientific computing in Python"
+TERMUX_PKG_LICENSE="BSD 3-Clause"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=1.8.0
+TERMUX_PKG_SRCURL=https://github.com/scipy/scipy.git
+TERMUX_PKG_DEPENDS="libc++, openblas, python, python-numpy"
+TERMUX_PKG_BUILD_DEPENDS="python-numpy-static"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+_PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
+_NUMPY_VERSION=$(. $TERMUX_SCRIPTDIR/tur/python-numpy/build.sh; echo $TERMUX_PKG_VERSION)
+_PKG_PYTHON_DEPENDS="numpy==$_NUMPY_VERSION"
+
+if $TERMUX_ON_DEVICE_BUILD; then
+	termux_error_exit "Package '$TERMUX_PKG_NAME' is not available for on-device builds."
+fi
+
+TERMUX_PKG_RM_AFTER_INSTALL="
+bin/
+"
+
+# XXX: This step will setup an old NDK toolchain (r17c) containing gcc and
+# XXX: gfortran. If NDK toolchain with llvm contains fortran compiler, this
+# XXX: step may be unnecessary.
+_setup_fortran_toolchain_r17c() {
+	mkdir -p $TERMUX_COMMON_CACHEDIR/android-gfortran/r17c
+	local _NDK_ARCHIVE_FILE=$TERMUX_COMMON_CACHEDIR/android-gfortran/android-ndk-r17c-linux-x86_64.zip
+	local _NDK_URL=https://dl.google.com/android/repository/android-ndk-r17c-linux-x86_64.zip
+	local _NDK_SHA256=3f541adbd0330a9205ba12697f6d04ec90752c53d6b622101a2a8a856e816589
+	local _NDK_GF_ARCH
+	local _NDK_GF_SHA256
+	if [ "$TERMUX_ARCH" == "aarch64" ]; then
+		_NDK_GF_ARCH="arm64"
+		_NDK_GF_SHA256=dcbed5edeabb77533fcef0e76a9da9e4b1e23089f3a6be31824ff411058df7fd
+		_NDK_GF_TOOLCHAIN_NAME="aarch64-linux-android-4.9"
+	elif [ "$TERMUX_ARCH" == "arm" ]; then
+		_NDK_GF_ARCH="arm"
+		_NDK_GF_SHA256=75a15fd03e139f6326be604728cbec9d9d3d295942cc13d91766e40bcdd9a9e8
+		_NDK_GF_TOOLCHAIN_NAME="arm-linux-androideabi-4.9"
+	elif [ "$TERMUX_ARCH" == "x86_64" ]; then
+		_NDK_GF_ARCH="x86_64"
+		_NDK_GF_SHA256=27f683840e0453bd63cee5c9d3a6e41d2b90b4e86f20a13e74f78a9699d73401
+		_NDK_GF_TOOLCHAIN_NAME="x86_64-4.9"
+	elif [ "$TERMUX_ARCH" == "i686" ]; then
+		_NDK_GF_ARCH="x86"
+		_NDK_GF_SHA256=35f1491a9067c1a593430ebda812346ed528921730f2473c8dd9e847401167a2
+		_NDK_GF_TOOLCHAIN_NAME="x86-4.9"
+	fi
+	local _NDK_GF_FILE=$TERMUX_COMMON_CACHEDIR/android-gfortran/r17c/gcc-$_NDK_GF_ARCH-linux-x86_64.tar.bz2
+	local _NDK_GF_URL=https://github.com/licy183/android-gfortran/releases/download/r17/gcc-$_NDK_GF_ARCH-linux-x86_64.tar.bz2
+	local _NDK_TOOLCHAIN_TARGET=$TERMUX_PKG_TMPDIR/android-ndk-r17c/toolchains/$_NDK_GF_TOOLCHAIN_NAME/prebuilt/linux-x86_64
+	termux_download $_NDK_URL $_NDK_ARCHIVE_FILE $_NDK_SHA256
+	unzip -d $TERMUX_PKG_TMPDIR/ $_NDK_ARCHIVE_FILE > /dev/null 2>&1
+	termux_download $_NDK_GF_URL $_NDK_GF_FILE $_NDK_GF_SHA256
+	tar -jxf $_NDK_GF_FILE -C $TERMUX_PKG_TMPDIR/
+	rm -rf $_NDK_TOOLCHAIN_TARGET
+	mv $TERMUX_PKG_TMPDIR/$_NDK_GF_TOOLCHAIN_NAME $_NDK_TOOLCHAIN_TARGET
+	export GFORTRAN_TOOLCHAIN=$TERMUX_PKG_TMPDIR/ndk-$TERMUX_ARCH-with-gfortran
+	python $TERMUX_PKG_TMPDIR/android-ndk-r17c/build/tools/make_standalone_toolchain.py \
+					--arch $_NDK_GF_ARCH --api $TERMUX_PKG_API_LEVEL --install-dir $GFORTRAN_TOOLCHAIN
+}
+
+termux_step_configure() {
+	_setup_fortran_toolchain_r17c
+	CFLAGS="${CFLAGS/-static-openmp/''}"
+	CXXFLAGS="${CXXFLAGS/-static-openmp/''}"
+	LDFLAGS="${LDFLAGS/-static-openmp/''}"
+
+	CROSS_PREFIX=$TERMUX_ARCH-linux-android
+	if [ "$TERMUX_ARCH" == "arm" ]; then
+		CROSS_PREFIX=arm-linux-androideabi
+	fi
+
+	# XXX: Only using gfortran, is it compatible with llvm?
+	export FC=$CROSS_PREFIX-gfortran
+	# XXX: `python` from main repo is built by TERMUX_STANDALONE_TOOLCHAIN and its _sysconfigdata.py
+	# XXX: contains some FLAGS which is not supported by clang/ld.lld from GFORTRAN_TOOLCHAIN,
+	# XXX: such as `-static-openmp`. Replacing these FLAGS in `_sysconfigdata.py` is a solution,
+	# XXX: but I think it is unnecessary. That is the reason why putting GFORTRAN_TOOLCHAIN
+	# XXX: behind TERMUX_STANDALONE_TOOLCHAIN.
+	export PATH="$PATH:$GFORTRAN_TOOLCHAIN/bin"
+
+	# We set `python-scipy` as dependencies, but python-crossenv prefer to use a fake one.
+	DEVICE_STIE=$TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages
+	pushd $DEVICE_STIE
+	_NUMPY_EGGDIR=
+	for f in numpy-${_NUMPY_VERSION}-py${_PYTHON_VERSION}-linux-*.egg; do
+		if [ -d "$f" ]; then
+			_NUMPY_EGGDIR="$f"
+			break
+		fi
+	done
+	test -n "${_NUMPY_EGGDIR}"
+	popd
+	mv $DEVICE_STIE/$_NUMPY_EGGDIR $TERMUX_PREFIX/tmp/$_NUMPY_EGGDIR
+
+	termux_setup_python_crossenv
+	pushd $TERMUX_PYTHON_CROSSENV_SRCDIR
+	_CROSSENV_PREFIX=$TERMUX_PKG_BUILDDIR/python-crossenv-prefix
+	python${_PYTHON_VERSION} -m crossenv \
+		$TERMUX_PREFIX/bin/python${_PYTHON_VERSION} \
+		${_CROSSENV_PREFIX}
+	popd
+	. ${_CROSSENV_PREFIX}/bin/activate
+
+	LDFLAGS+=" -Wl,--no-as-needed,-lpython${_PYTHON_VERSION}"
+}
+
+termux_step_make() {
+	MATHLIB="m" pip --no-cache-dir install $_PKG_PYTHON_DEPENDS wheel
+	build-pip install $_PKG_PYTHON_DEPENDS pybind11 Cython pythran wheel
+
+	# From https://gist.github.com/benfogle/85e9d35e507a8b2d8d9dc2175a703c22
+	BUILD_SITE=${_CROSSENV_PREFIX}/build/lib/python${_PYTHON_VERSION}/site-packages
+	CROSS_SITE=${_CROSSENV_PREFIX}/cross/lib/python${_PYTHON_VERSION}/site-packages
+	INI=$(find $BUILD_SITE -name 'npymath.ini')
+	LIBDIR=$(find $CROSS_SITE -path '*/numpy/core/lib')
+	INCDIR=$(find $CROSS_SITE -path '*/numpy/core/include')
+	cat <<-EOF > $INI 
+	[meta]
+	Name=npymath
+	Description=Portable, core math library implementing C99 standard
+	Version=0.1
+	[variables]
+	# Force it to find cross-build libs when we build scipy
+	libdir=$LIBDIR
+	includedir=$INCDIR
+	[default]
+	Libs=-L\${libdir} -lnpymath
+	Cflags=-I\${includedir}
+	Requires=mlib
+	EOF
+	_ADDTIONAL_FILES=()
+	cp $CROSS_SITE/numpy/core/lib/libnpymath.a $TERMUX_PREFIX/lib
+	cp $CROSS_SITE/numpy/random/lib/libnpyrandom.a $TERMUX_PREFIX/lib
+	_ADDTIONAL_FILES+=("$TERMUX_PREFIX/lib/libnpymath.a")
+	_ADDTIONAL_FILES+=("$TERMUX_PREFIX/lib/libnpyrandom.a")
+	cat <<- EOF > site.cfg
+	[openblas]
+	libraries = openblas
+	library_dirs = $TERMUX_PREFIX/lib
+	include_dirs = $TERMUX_PREFIX/include
+	EOF
+
+	F90=$FC F77=$FC python setup.py install --force
+}
+
+termux_step_make_install() {
+	export PYTHONPATH="$DEVICE_STIE"
+	F90=$FC F77=$FC python setup.py install --force --prefix $TERMUX_PREFIX
+
+	pushd $DEVICE_STIE
+	_SCIPY_EGGDIR=
+	for f in scipy-${TERMUX_PKG_VERSION}-py${_PYTHON_VERSION}-linux-*.egg; do
+		if [ -d "$f" ]; then
+			_SCIPY_EGGDIR="$f"
+			break
+		fi
+	done
+	test -n "${_SCIPY_EGGDIR}"
+	popd
+}
+
+termux_step_post_make_install() {
+	# Remove these dummy files.
+	rm "${_ADDTIONAL_FILES[@]}"
+	# Recovery numpy
+	mv $TERMUX_PREFIX/tmp/$_NUMPY_EGGDIR $DEVICE_STIE/$_NUMPY_EGGDIR
+	# Delete the easy-install related files, since we use postinst/prerm to handle it.
+	pushd $TERMUX_PREFIX
+	rm -rf lib/python${_PYTHON_VERSION}/site-packages/__pycache__
+	rm -rf lib/python${_PYTHON_VERSION}/site-packages/easy-install.pth
+	rm -rf lib/python${_PYTHON_VERSION}/site-packages/site.py
+	popd
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	echo "Installing dependencies through pip. This may take a while..."
+	pip3 install ${_PKG_PYTHON_DEPENDS}
+	echo "./${_SCIPY_EGGDIR}" >> $TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages/easy-install.pth
+	EOF
+
+	cat <<- EOF > ./prerm
+	#!$TERMUX_PREFIX/bin/sh
+	sed -i "/\.\/${_SCIPY_EGGDIR//./\\.}/d" $TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages/easy-install.pth
+	EOF
+}

--- a/tur/python-numpy/build.sh
+++ b/tur/python-numpy/build.sh
@@ -1,0 +1,77 @@
+TERMUX_PKG_HOMEPAGE=https://numpy.org/
+TERMUX_PKG_DESCRIPTION="The fundamental package for scientific computing with Python"
+TERMUX_PKG_LICENSE="BSD 3-Clause"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+# Don't forget to bump the REVISION of python-scipy.
+TERMUX_PKG_VERSION=1.23.0
+TERMUX_PKG_SRCURL=https://github.com/numpy/numpy.git
+TERMUX_PKG_PROVIDES="python-numpy"
+TERMUX_PKG_DEPENDS="libc++, python"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+_PYTHON_VERSION=$(. $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
+
+TERMUX_PKG_RM_AFTER_INSTALL="
+bin/
+"
+
+if $TERMUX_ON_DEVICE_BUILD; then
+	termux_error_exit "Package '$TERMUX_PKG_NAME' is not available for on-device builds."
+fi
+
+termux_step_configure() {
+	termux_setup_python_crossenv
+	pushd $TERMUX_PYTHON_CROSSENV_SRCDIR
+	_CROSSENV_PREFIX=$TERMUX_PKG_BUILDDIR/python-crossenv-prefix
+	python${_PYTHON_VERSION} -m crossenv \
+		$TERMUX_PREFIX/bin/python${_PYTHON_VERSION} \
+		${_CROSSENV_PREFIX}
+	popd
+	. ${_CROSSENV_PREFIX}/bin/activate
+
+	LDFLAGS+=" -lpython${_PYTHON_VERSION}"
+}
+
+termux_step_make() {
+	build-pip install pybind11 Cython pythran wheel
+	DEVICE_STIE=$TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages
+	MATHLIB="m" python setup.py install --force
+}
+
+termux_step_make_install() {
+	export PYTHONPATH="$DEVICE_STIE"
+	MATHLIB="m" python setup.py install --force --prefix $TERMUX_PREFIX
+
+	pushd $DEVICE_STIE
+	_NUMPY_EGGDIR=
+	for f in numpy-${TERMUX_PKG_VERSION}-py${_PYTHON_VERSION}-linux-*.egg; do
+		if [ -d "$f" ]; then
+			_NUMPY_EGGDIR="$f"
+			break
+		fi
+	done
+	test -n "${_NUMPY_EGGDIR}"
+	popd
+}
+
+termux_step_post_make_install() {
+	# Delete the easy-install related files, since we use postinst/prerm to handle it.
+	pushd $TERMUX_PREFIX
+	rm -rf lib/python${_PYTHON_VERSION}/site-packages/__pycache__
+	rm -rf lib/python${_PYTHON_VERSION}/site-packages/easy-install.pth
+	rm -rf lib/python${_PYTHON_VERSION}/site-packages/site.py
+	popd
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	echo "Installing numpy..."
+	echo "./${_NUMPY_EGGDIR}" >> $TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages/easy-install.pth
+	EOF
+
+	cat <<- EOF > ./prerm
+	#!$TERMUX_PREFIX/bin/sh
+	sed -i "/\.\/${_NUMPY_EGGDIR//./\\.}/d" $TERMUX_PREFIX/lib/python${_PYTHON_VERSION}/site-packages/easy-install.pth
+	EOF
+}


### PR DESCRIPTION
These packages are built with old NDK toolchain, and I think they will not be accepted by the main repo.

Test results are as following:

**Numpy Test Results**

| Architecture / RAM Size | Android Version | Result | Comment |
| :----: | :----: | :----: | :----: |
| AArch64 / 12G | 11.0 | 18 failed, 17619 passed, 342 skipped, 1302 deselected, 39 xfailed, 2 xpassed, 9 errors in 165.51s (0:02:45) | |
| ARM / 6G | 9.0 | 4 failed, 17071 passed, 1191 skipped, 1302 deselected, 39 xfailed, 2 xpassed, 19 warnings, 9 errors in 380.60s (0:06:20) | |
| X86-64 / 4G | 7.0 | 8 failed, 17721 passed, 1442 skipped, 1302 deselected, 36 xfailed, 5 xpassed, 4 warnings, 9 errors in 113.52s (0:01:53) | On a BlueStacks 5 VM |
| X86 / 4G | 7.0 | 3 failed, 17707 passed, 1450 skipped, 1302 deselected, 39 xfailed, 2 xpassed, 4 warnings, 9 errors in 125.58s (0:02:05) | On a BlueStacks 5 VM |

**Scipy Test Results**

| Architecture / RAM Size | Android Version | Result | Comment |
| :----: | :----: | :----: | :----: |
| AArch64 / 12G | 11.0 | 370 failed, 35036 passed, 2758 skipped, 11452 deselected, 104 xfailed, 10 xpassed, 120 warnings in 957.88s (0:15:57) | |
| ARM / 6G | 9.0 | 15 failed, 18834 passed, 27 skipped, 11424 deselected, 344 xfailed, 10 xpassed, 26 warnings in 3499.34s (0:58:19)  | Testing are lagging for about 30 minutes when executing signal/tests/test_signaltools.py, so it was cancelled midway. |
| X86-64 / 4G | 7.0 | 5 failed, 35403 passed, 2755 skipped, 11452 deselected, 104 xfailed, 11 xpassed, 28 warnings in 490.26s (0:08:10) | On a BlueStacks 5 VM |
| X86 / 4G | 7.0 | Invalid | On a BlueStacks 5 VM. Segmentation fault when executing linalg/tests/test_basic.py. |

I wonder if scipy in this Pull Request is acceptable to be added to this repo. 

Any ideas? @kcubeterm @2096779623
