### PR TITLE
new package: sqawk

### DIFF
--- a/tur/sqawk/build.sh
+++ b/tur/sqawk/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/dbohdan/sqawk
+TERMUX_PKG_DESCRIPTION="Manipulate csv/tsv/json data using SQL in an AWK-like fashion (sqlite-tcl as backend with db dump)"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@flosnvjx, @termux-user-repository"
+TERMUX_PKG_VERSION=0.23.1
+TERMUX_PKG_SRCURL=https://github.com/dbohdan/sqawk/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SHA256=e689a776d94f6e3bd735b6a96ef0b17e2b88a81541b6b7edb67132f71ddaa99c
+TERMUX_PKG_DEPENDS="tcl, tcllib, libsqlite-tcl"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+
+termux_step_make_install() {
+	make prefix=$TERMUX_PREFIX install
+	install -dm700 $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME
+	cp -r examples/ $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME
+	install -pm600 README.* -t $TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME
+}


### PR DESCRIPTION
~~tcllib is the standard library of tcl.  Some module like `ftpd` use hardcoded path (we have busybox anyway).~~

sqawk is a maintained CLI utility depends on tcllib -- have to say that only [a few](https://github.com/search?q=language%3Atcl+stars%3A%3E50+pushed%3A%3E2020-01-01&ref=simplesearch) maintained project on GitHub still use tcl, too few to create a `termux_setup_tcl` for it.
