### PR TITLE
new package: fakepkg

### DIFF
--- a/tur/fakepkg/00-hardcoded-path.patch
+++ b/tur/fakepkg/00-hardcoded-path.patch
@@ -1,0 +1,31 @@
+diff --git a/fakepkg b/fakepkg
+index 0f3647d..b6b30d0 100755
+--- a/fakepkg
++++ b/fakepkg
+@@ -17,7 +17,7 @@ declare -r myver='1.42.2'
+ declare -r tmp_root='fakepkg'
+ 
+ # Standard path where pacman db resides
+-declare -r db_path='/var/lib/pacman'
++declare -r db_path='@TERMUX_PREFIX@/var/lib/pacman'
+ 
+ # Error codes
+ declare -r ERROR_USAGE=1
+@@ -41,7 +41,7 @@ function fakebuild() {
+ 	fi
+ 
+ 	# Create and enter a temporary dir
+-	TMPDIR=$(mktemp -q -p /tmp -t -d "${tmp_root}".XXX)
++	TMPDIR=$(mktemp -q -p @TERMUX_PREFIX@/tmp -t -d "${tmp_root}".XXX)
+ 	cd "${TMPDIR}" || return ${ERROR_OPERATION}
+ 
+ 	# Fetching the .PKGINFO, .Changelog, .MTREE and .INSTALL file
+@@ -173,7 +173,7 @@ function version() {
+ 
+ # Clean up temporary dirs recursively
+ function clean_up {
+-	rm -r /tmp/"${tmp_root}".*
++	rm -r @TERMUX_PREFIX@/tmp/"${tmp_root}".*
+ 	echo
+ 	exit
+ }

--- a/tur/fakepkg/01-android-chdir-fsroot-eperm-gnutar-dieout-fix.patch
+++ b/tur/fakepkg/01-android-chdir-fsroot-eperm-gnutar-dieout-fix.patch
@@ -1,0 +1,32 @@
+diff --git a/fakepkg b/fakepkg
+index b53f73b..33157c0 100755
+--- a/fakepkg
++++ b/fakepkg
+@@ -95,22 +95,12 @@ function fakebuild() {
+ 
+ 	# Taring things together
+ 	if [[ $3 -ge "1" ]]; then
+-		#XZ_OPT="-T 0" \
+-		tar --ignore-failed-read --owner=0 --group=0 --no-recursion -c -a \
+-			--force-local -f "${PKG_NAME}${PKGEXT}" \
+-			-C "${ROOT_DIR:-/}" -T ./package_file_list -C "$TMPDIR" \
+-			"${aux_files[@]}"
++		bsdtar -cnf - -C "${ROOT_DIR:-/}" -T ./package_file_list
++		bsdtar -cf - -C "$TMPDIR" "${aux_files[@]}"
+ 	else
+-		#XZ_OPT="-T 0" \
+-		if tar --ignore-failed-read --owner=0 --group=0 --no-recursion -c -a \
+-			--force-local -f "${PKG_NAME}${PKGEXT}" \
+-			-C "${ROOT_DIR:-/}" -T ./package_file_list -C "$TMPDIR" \
+-			"${aux_files[@]}" 2>&1 >/dev/null \
+-			| grep -i "permission denied" >/dev/null -; then
+-
+-			>&2 echo -e "The permission to open one or more directories was denied for \e[39;1m${PKG_NAME}\e[0m. The package may be incomplete!"
+-		fi
+-	fi
++		bsdtar -cnf - -C "${ROOT_DIR:-/}" -T ./package_file_list 2>/dev/null
++		bsdtar -cf - -C "$TMPDIR" "${aux_files[@]}"
++	fi | bsdtar -caf "${PKG_NAME}${PKGEXT}" --format cpio --ignore-zeros --uid=0 --gid=0 @-
+ 
+ 	# Cleanup
+ 	if [[ -f ${PKG_NAME}${PKGEXT} ]]; then

--- a/tur/fakepkg/build.sh
+++ b/tur/fakepkg/build.sh
@@ -1,0 +1,26 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/Edenhofer/fakepkg
+TERMUX_PKG_DESCRIPTION="Reassemble installed package from filesystem tree per libalpm database (bacman analogue)"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@flosnvjx"
+TERMUX_PKG_VERSION=1.42.2
+TERMUX_PKG_SRCURL=https://github.com/Edenhofer/fakepkg/archive/refs/tags/v"$TERMUX_PKG_VERSION".tar.gz
+TERMUX_PKG_SHA256=31ca1e3483ffe5b897ebc5997ebdec1342904d6f8f4b51ea77a4aea01ed7b38d
+TERMUX_PKG_DEPENDS="file, bsdtar, pacman"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
+
+termux_step_configure() {
+	true
+}
+
+termux_step_make() {
+	curl -qgsfL https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt \
+		-o LICENSE
+}
+
+termux_step_make_install() {
+	install -Dm700 -t $TERMUX_PREFIX/bin fakepkg
+	install -Dm600 -t $TERMUX_PREFIX/share/man/man1 man/fakepkg.1
+}


### PR DESCRIPTION
what: modern analogue of deprecated `bacman(8)` script, which is previously dist within pacman as a contrib script, https://gitlab.archlinux.org/pacman/pacman/-/commit/ae56a32273df8a36f4e84e0f37ce1f34e84f15a3