### PR TITLE
new package: nodejs-16

### DIFF
--- a/tur/code-server/build.sh
+++ b/tur/code-server/build.sh
@@ -3,9 +3,9 @@ TERMUX_PKG_DESCRIPTION="Run VS Code on any machine anywhere and access it in the
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION=4.8.3
-TERMUX_PKG_REVISION=2
+TERMUX_PKG_REVISION=3
 TERMUX_PKG_SRCURL=https://github.com/coder/code-server.git
-TERMUX_PKG_DEPENDS="libsecret, nodejs-lts, ripgrep"
+TERMUX_PKG_DEPENDS="libsecret, nodejs-16, ripgrep"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_HOSTBUILD=true
 TERMUX_PKG_NO_STATICSPLIT=true
@@ -71,7 +71,7 @@ termux_step_make_install() {
 	cp -Rf ./release-standalone/* $TERMUX_PREFIX/lib/code-server/
 
 	# Replace nodejs
-	ln -sf $TERMUX_PREFIX/bin/node $TERMUX_PREFIX/lib/code-server/lib/node
+	ln -sf $TERMUX_PREFIX/opt/nodejs-16/bin/node $TERMUX_PREFIX/lib/code-server/lib/node
 
 	# Replace ripgrep
 	ln -sf $TERMUX_PREFIX/bin/rg $TERMUX_PREFIX/lib/code-server/lib/vscode/node_modules/@vscode/ripgrep/bin/rg

--- a/tur/nodejs-16/avoid-ficlone-ioctl.patch
+++ b/tur/nodejs-16/avoid-ficlone-ioctl.patch
@@ -1,0 +1,19 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/src/unix/fs.c node-v16.14.2/deps/uv/src/unix/fs.c
+--- node-v16.14.2.orig/deps/uv/src/unix/fs.c	2022-03-18 15:06:20.191091189 +0530
++++ node-v16.14.2/deps/uv/src/unix/fs.c	2022-03-18 15:07:35.021091161 +0530
+@@ -1339,6 +1339,7 @@
+ #endif  /* !__linux__ */
+   }
+ 
++#ifndef __ANDROID__
+ #ifdef FICLONE
+   if (req->flags & UV_FS_COPYFILE_FICLONE ||
+       req->flags & UV_FS_COPYFILE_FICLONE_FORCE) {
+@@ -1359,6 +1360,7 @@
+     goto out;
+   }
+ #endif
++#endif
+ 
+   bytes_to_send = src_statsbuf.st_size;
+   in_offset = 0;

--- a/tur/nodejs-16/build.sh
+++ b/tur/nodejs-16/build.sh
@@ -1,0 +1,110 @@
+TERMUX_PKG_HOMEPAGE=https://nodejs.org/
+TERMUX_PKG_DESCRIPTION="Open Source, cross-platform JavaScript runtime environment"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=16.18.1
+TERMUX_PKG_SRCURL=https://nodejs.org/dist/v${TERMUX_PKG_VERSION}/node-v${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=1f8051a88f86f42064f4415fe7a980e59b0a502ecc8def583f6303bc4d445238
+# Note that we do not use a shared libuv to avoid an issue with the Android
+# linker, which does not use symbols of linked shared libraries when resolving
+# symbols on dlopen(). See https://github.com/termux/termux-packages/issues/462.
+#
+# Node.js 16.x does not support `NODE_OPTIONS=--openssl-legacy-provider` option.
+# See https://github.com/termux/termux-packages/issues/9266. Please revert back
+# to depending on openssl (instead of openssl-1.1) when migrating to next LTS.
+TERMUX_PKG_DEPENDS="libc++, openssl-1.1, c-ares, libicu, zlib"
+TERMUX_PKG_SUGGESTS="clang, make, pkg-config, python"
+_INSTALL_PREFIX=opt/nodejs-16
+TERMUX_PKG_RM_AFTER_INSTALL="
+$_INSTALL_PREFIX/lib/node_modules/npm/html
+$_INSTALL_PREFIX/lib/node_modules/npm/make.bat
+$_INSTALL_PREFIX/share/systemtap
+$_INSTALL_PREFIX/lib/dtrace
+"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_HOSTBUILD=true
+
+termux_step_post_get_source() {
+	# Prevent caching of host build:
+	rm -Rf $TERMUX_PKG_HOSTBUILD_DIR
+}
+
+termux_step_host_build() {
+	local ICU_VERSION=72.1
+	local ICU_TAR=icu4c-${ICU_VERSION//./_}-src.tgz
+	local ICU_DOWNLOAD=https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION//./-}/$ICU_TAR
+	termux_download \
+		$ICU_DOWNLOAD\
+		$TERMUX_PKG_CACHEDIR/$ICU_TAR \
+		a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68
+	tar xf $TERMUX_PKG_CACHEDIR/$ICU_TAR
+	cd icu/source
+	if [ "$TERMUX_ARCH_BITS" = 32 ]; then
+		./configure --prefix $TERMUX_PKG_HOSTBUILD_DIR/icu-installed \
+			--disable-samples \
+			--disable-tests \
+			--build=i686-pc-linux-gnu "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32"
+	else
+		./configure --prefix $TERMUX_PKG_HOSTBUILD_DIR/icu-installed \
+			--disable-samples \
+			--disable-tests
+	fi
+	make -j $TERMUX_MAKE_PROCESSES install
+}
+
+termux_step_configure() {
+	local DEST_CPU
+	if [ $TERMUX_ARCH = "arm" ]; then
+		DEST_CPU="arm"
+	elif [ $TERMUX_ARCH = "i686" ]; then
+		DEST_CPU="ia32"
+	elif [ $TERMUX_ARCH = "aarch64" ]; then
+		DEST_CPU="arm64"
+	elif [ $TERMUX_ARCH = "x86_64" ]; then
+		DEST_CPU="x64"
+	else
+		termux_error_exit "Unsupported arch '$TERMUX_ARCH'"
+	fi
+
+	export GYP_DEFINES="host_os=linux"
+	export CC_host=gcc
+	export CXX_host=g++
+	export LINK_host=g++
+
+	LDFLAGS+=" -ldl"
+
+	local _SHARED_OPENSSL_INCLUDES=$TERMUX_PREFIX/include
+	local _SHARED_OPENSSL_LIBPATH=$TERMUX_PREFIX/lib
+
+	if [ "${TERMUX_PKG_VERSION%%.*}" != "16" ]; then
+		termux_error_exit 'Please migrate to using openssl (instead of openssl-1.1).'
+	else
+		_SHARED_OPENSSL_INCLUDES=$TERMUX_PREFIX/include/openssl-1.1
+		_SHARED_OPENSSL_LIBPATH=$TERMUX_PREFIX/lib/openssl-1.1
+		LDFLAGS="-Wl,-rpath=$_SHARED_OPENSSL_LIBPATH $LDFLAGS"
+	fi
+
+	mkdir -p $TERMUX_PREFIX/$_INSTALL_PREFIX
+	LDFLAGS="-Wl,-rpath=$TERMUX_PREFIX/$_INSTALL_PREFIX/lib $LDFLAGS"
+
+	# See note above TERMUX_PKG_DEPENDS why we do not use a shared libuv.
+	./configure \
+		--prefix=$TERMUX_PREFIX/$_INSTALL_PREFIX \
+		--dest-cpu=$DEST_CPU \
+		--dest-os=android \
+		--shared-cares \
+		--shared-openssl \
+		--shared-openssl-includes=$_SHARED_OPENSSL_INCLUDES \
+		--shared-openssl-libpath=$_SHARED_OPENSSL_LIBPATH \
+		--shared-zlib \
+		--with-intl=system-icu \
+		--cross-compiling
+
+	export LD_LIBRARY_PATH=$TERMUX_PKG_HOSTBUILD_DIR/icu-installed/lib
+	perl -p -i -e "s@LIBS := \\$\\(LIBS\\)@LIBS := -L$TERMUX_PKG_HOSTBUILD_DIR/icu-installed/lib -lpthread -licui18n -licuuc -licudata -ldl -lz@" \
+		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/mksnapshot.host.mk \
+		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/torque.host.mk \
+		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/bytecode_builtins_list_generator.host.mk \
+		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/v8_libbase.host.mk \
+		$TERMUX_PKG_SRCDIR/out/tools/v8_gypfiles/gen-regexp-special-case.host.mk
+}

--- a/tur/nodejs-16/configure.py.patch
+++ b/tur/nodejs-16/configure.py.patch
@@ -1,0 +1,13 @@
+--- ./configure.py.orig	2022-10-20 13:35:36.500629016 +0530
++++ ./configure.py	2022-10-20 13:35:54.980629009 +0530
+@@ -1241,10 +1241,6 @@
+ 
+   o['variables']['want_separate_host_toolset'] = int(cross_compiling)
+ 
+-  # Enable branch protection for arm64
+-  if target_arch == 'arm64':
+-    o['cflags']+=['-msign-return-address=all']
+-
+   if options.node_snapshot_main is not None:
+     if options.shared:
+       # This should be possible to fix, but we will need to refactor the

--- a/tur/nodejs-16/deps-npm-node_modules-cacache-lib-util-move-file.js.patch
+++ b/tur/nodejs-16/deps-npm-node_modules-cacache-lib-util-move-file.js.patch
@@ -1,0 +1,60 @@
+--- ./deps/npm/node_modules/cacache/lib/util/move-file.js.orig	2022-06-06 17:56:02.433293902 +0530
++++ ./deps/npm/node_modules/cacache/lib/util/move-file.js	2022-06-06 17:56:56.713293882 +0530
+@@ -1,56 +1,9 @@
+ 'use strict'
+ 
+-const fs = require('@npmcli/fs')
+ const move = require('@npmcli/move-file')
+-const pinflight = require('promise-inflight')
+ 
+ module.exports = moveFile
+ 
+ async function moveFile (src, dest) {
+-  const isWindows = process.platform === 'win32'
+-
+-  // This isn't quite an fs.rename -- the assumption is that
+-  // if `dest` already exists, and we get certain errors while
+-  // trying to move it, we should just not bother.
+-  //
+-  // In the case of cache corruption, users will receive an
+-  // EINTEGRITY error elsewhere, and can remove the offending
+-  // content their own way.
+-  //
+-  // Note that, as the name suggests, this strictly only supports file moves.
+-  try {
+-    await fs.link(src, dest)
+-  } catch (err) {
+-    if (isWindows && err.code === 'EPERM') {
+-      // XXX This is a really weird way to handle this situation, as it
+-      // results in the src file being deleted even though the dest
+-      // might not exist.  Since we pretty much always write files to
+-      // deterministic locations based on content hash, this is likely
+-      // ok (or at worst, just ends in a future cache miss).  But it would
+-      // be worth investigating at some time in the future if this is
+-      // really what we want to do here.
+-    } else if (err.code === 'EEXIST' || err.code === 'EBUSY') {
+-      // file already exists, so whatever
+-    } else {
+-      throw err
+-    }
+-  }
+-  try {
+-    await Promise.all([
+-      fs.unlink(src),
+-      !isWindows && fs.chmod(dest, '0444'),
+-    ])
+-  } catch (e) {
+-    return pinflight('cacache-move-file:' + dest, async () => {
+-      await fs.stat(dest).catch((err) => {
+-        if (err.code !== 'ENOENT') {
+-          // Something else is wrong here. Bail bail bail
+-          throw err
+-        }
+-      })
+-      // file doesn't already exist! let's try a rename -> copy fallback
+-      // only delete if it successfully copies
+-      return move(src, dest)
+-    })
+-  }
++  return move(src, dest);
+ }

--- a/tur/nodejs-16/deps-uv-src-unix-core.c.patch
+++ b/tur/nodejs-16/deps-uv-src-unix-core.c.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/src/unix/core.c node-v16.14.2/deps/uv/src/unix/core.c
+--- node-v16.14.2.orig/deps/uv/src/unix/core.c	2022-03-18 15:06:20.191091189 +0530
++++ node-v16.14.2/deps/uv/src/unix/core.c	2022-03-18 15:07:54.421091153 +0530
+@@ -1125,7 +1125,7 @@
+ 
+   /* No temp environment variables defined */
+   #if defined(__ANDROID__)
+-    buf = "/data/local/tmp";
++    buf = "@TERMUX_PREFIX@/tmp";
+   #else
+     buf = "/tmp";
+   #endif

--- a/tur/nodejs-16/deps-uv-src-unix-process.c.patch
+++ b/tur/nodejs-16/deps-uv-src-unix-process.c.patch
@@ -1,0 +1,27 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/src/unix/process.c node-v16.14.2/deps/uv/src/unix/process.c
+--- node-v16.14.2.orig/deps/uv/src/unix/process.c	2022-03-18 15:06:20.201091189 +0530
++++ node-v16.14.2/deps/uv/src/unix/process.c	2022-03-18 15:08:12.121091146 +0530
+@@ -303,23 +303,6 @@
+   if (options->cwd != NULL && chdir(options->cwd))
+     uv__write_errno(error_fd);
+ 
+-  if (options->flags & (UV_PROCESS_SETUID | UV_PROCESS_SETGID)) {
+-    /* When dropping privileges from root, the `setgroups` call will
+-     * remove any extraneous groups. If we don't call this, then
+-     * even though our uid has dropped, we may still have groups
+-     * that enable us to do super-user things. This will fail if we
+-     * aren't root, so don't bother checking the return value, this
+-     * is just done as an optimistic privilege dropping function.
+-     */
+-    SAVE_ERRNO(setgroups(0, NULL));
+-  }
+-
+-  if ((options->flags & UV_PROCESS_SETGID) && setgid(options->gid))
+-    uv__write_errno(error_fd);
+-
+-  if ((options->flags & UV_PROCESS_SETUID) && setuid(options->uid))
+-    uv__write_errno(error_fd);
+-
+   if (options->env != NULL) {
+     environ = options->env;
+   }

--- a/tur/nodejs-16/deps-uv-uv.gyp.patch
+++ b/tur/nodejs-16/deps-uv-uv.gyp.patch
@@ -1,0 +1,29 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/uv.gyp node-v16.14.2/deps/uv/uv.gyp
+--- node-v16.14.2.orig/deps/uv/uv.gyp	2022-03-18 15:06:20.271091189 +0530
++++ node-v16.14.2/deps/uv/uv.gyp	2022-03-18 15:08:18.801091144 +0530
+@@ -40,7 +40,7 @@
+     {
+       'target_name': 'libuv',
+       'type': '<(uv_library)',
+-      'include_dirs': [
++      'include_dirs+': [
+         'include',
+         'src/',
+       ],
+@@ -55,7 +55,7 @@
+           '<@(shared_unix_defines)',
+           '<@(shared_zos_defines)',
+         ],
+-        'include_dirs': [ 'include' ],
++        'include_dirs+': [ 'include' ],
+         'conditions': [
+           ['OS == "linux"', {
+             'defines': [ '_POSIX_C_SOURCE=200112' ],
+@@ -247,6 +247,7 @@
+             'src/unix/procfs-exepath.c',
+             'src/unix/random-getrandom.c',
+             'src/unix/random-sysctl-linux.c',
++            'src/unix/epoll.c',
+           ],
+           'link_settings': {
+             'libraries': [ '-ldl', '-lrt' ],

--- a/tur/nodejs-16/deps-v8-src-flags-flag-definitions.h.patch
+++ b/tur/nodejs-16/deps-v8-src-flags-flag-definitions.h.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/v8/src/flags/flag-definitions.h node-v16.14.2/deps/v8/src/flags/flag-definitions.h
+--- node-v16.14.2.orig/deps/v8/src/flags/flag-definitions.h	2022-03-18 15:06:21.241091189 +0530
++++ node-v16.14.2/deps/v8/src/flags/flag-definitions.h	2022-03-18 15:08:21.471091143 +0530
+@@ -1980,7 +1980,7 @@
+ #undef DEFINE_PERF_PROF_BOOL
+ #undef DEFINE_PERF_PROF_IMPLICATION
+ 
+-DEFINE_STRING(gc_fake_mmap, "/tmp/__v8_gc__",
++DEFINE_STRING(gc_fake_mmap, "@TERMUX_PREFIX@/tmp/__v8_gc__",
+               "Specify the name of the file for fake gc mmap used in ll_prof")
+ DEFINE_BOOL(log_internal_timer_events, false, "Time internal events.")
+ DEFINE_IMPLICATION(log_internal_timer_events, prof)

--- a/tur/nodejs-16/deps-v8-src-logging-log.cc.patch
+++ b/tur/nodejs-16/deps-v8-src-logging-log.cc.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/v8/src/logging/log.cc node-v16.14.2/deps/v8/src/logging/log.cc
+--- node-v16.14.2.orig/deps/v8/src/logging/log.cc	2022-03-18 15:06:21.641091189 +0530
++++ node-v16.14.2/deps/v8/src/logging/log.cc	2022-03-18 15:08:24.351091142 +0530
+@@ -308,7 +308,7 @@
+   FILE* perf_output_handle_;
+ };
+ 
+-const char PerfBasicLogger::kFilenameFormatString[] = "/tmp/perf-%d.map";
++const char PerfBasicLogger::kFilenameFormatString[] = "@TERMUX_PREFIX@/tmp/perf-%d.map";
+ // Extra space for the PID in the filename
+ const int PerfBasicLogger::kFilenameBufferPadding = 16;
+ 

--- a/tur/nodejs-16/deps-v8-src-trap-handler-trap-handler.h.patch
+++ b/tur/nodejs-16/deps-v8-src-trap-handler-trap-handler.h.patch
@@ -1,0 +1,26 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/v8/src/trap-handler/trap-handler.h node-v16.14.2/deps/v8/src/trap-handler/trap-handler.h
+--- node-v16.14.2.orig/deps/v8/src/trap-handler/trap-handler.h	2022-03-18 15:06:22.041091188 +0530
++++ node-v16.14.2/deps/v8/src/trap-handler/trap-handler.h	2022-03-18 15:08:37.101091137 +0530
+@@ -17,22 +17,7 @@
+ namespace internal {
+ namespace trap_handler {
+ 
+-// X64 on Linux, Windows, MacOS, FreeBSD.
+-#if V8_HOST_ARCH_X64 && V8_TARGET_ARCH_X64 &&                        \
+-    ((V8_OS_LINUX && !V8_OS_ANDROID) || V8_OS_WIN || V8_OS_MACOSX || \
+-     V8_OS_FREEBSD)
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// Arm64 (non-simulator) on Mac.
+-#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_ARM64 && V8_OS_MACOSX
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// Arm64 simulator on x64 on Linux or Mac.
+-#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_X64 && (V8_OS_LINUX || V8_OS_MACOSX)
+-#define V8_TRAP_HANDLER_VIA_SIMULATOR
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// Everything else is unsupported.
+-#else
+ #define V8_TRAP_HANDLER_SUPPORTED false
+-#endif
+ 
+ // Setup for shared library export.
+ #if defined(BUILDING_V8_SHARED) && defined(V8_OS_WIN)

--- a/tur/nodejs-16/fix_multiple_definitions.patch
+++ b/tur/nodejs-16/fix_multiple_definitions.patch
@@ -1,0 +1,19 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/deps/uv/src/unix/sysinfo-memory.c node-v16.14.2/deps/uv/src/unix/sysinfo-memory.c
+--- node-v16.14.2.orig/deps/uv/src/unix/sysinfo-memory.c	2022-03-18 15:06:20.201091189 +0530
++++ node-v16.14.2/deps/uv/src/unix/sysinfo-memory.c	2022-03-18 15:08:41.551091135 +0530
+@@ -25,6 +25,7 @@
+ #include <stdint.h>
+ #include <sys/sysinfo.h>
+ 
++#ifndef __ANDROID__
+ uint64_t uv_get_free_memory(void) {
+   struct sysinfo info;
+ 
+@@ -32,6 +33,7 @@
+     return (uint64_t) info.freeram * info.mem_unit;
+   return 0;
+ }
++#endif
+ 
+ uint64_t uv_get_total_memory(void) {
+   struct sysinfo info;

--- a/tur/nodejs-16/lib-child_process.js.patch
+++ b/tur/nodejs-16/lib-child_process.js.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/lib/child_process.js node-v16.14.2/lib/child_process.js
+--- node-v16.14.2.orig/lib/child_process.js	2022-03-18 15:06:23.711091188 +0530
++++ node-v16.14.2/lib/child_process.js	2022-03-18 15:08:43.931091134 +0530
+@@ -589,7 +589,7 @@
+       if (typeof options.shell === 'string')
+         file = options.shell;
+       else if (process.platform === 'android')
+-        file = '/system/bin/sh';
++        file = '@TERMUX_PREFIX@/bin/sh';
+       else
+         file = '/bin/sh';
+       args = ['-c', command];

--- a/tur/nodejs-16/lib-os.js.patch
+++ b/tur/nodejs-16/lib-os.js.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/lib/os.js node-v16.14.2/lib/os.js
+--- node-v16.14.2.orig/lib/os.js	2022-03-18 15:06:23.831091188 +0530
++++ node-v16.14.2/lib/os.js	2022-03-18 15:08:46.251091133 +0530
+@@ -183,7 +183,7 @@
+     path = safeGetenv('TMPDIR') ||
+            safeGetenv('TMP') ||
+            safeGetenv('TEMP') ||
+-           '/tmp';
++           '@TERMUX_PREFIX@/tmp';
+     if (path.length > 1 && StringPrototypeEndsWith(path, '/'))
+       path = StringPrototypeSlice(path, 0, -1);
+   }

--- a/tur/nodejs-16/node.gyp.patch
+++ b/tur/nodejs-16/node.gyp.patch
@@ -1,0 +1,239 @@
+--- ./node.gyp.orig	2022-10-12 17:19:36.000000000 +0530
++++ ./node.gyp	2022-10-20 06:36:48.853792369 +0530
+@@ -402,6 +402,7 @@
+ 
+       'include_dirs': [
+         'src',
++        'deps/cares/src/lib',
+         '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
+       ],
+       'dependencies': [
+@@ -1126,165 +1127,6 @@
+         }],
+       ],
+     }, # fuzz_env
+-    {
+-      'target_name': 'cctest',
+-      'type': 'executable',
+-
+-      'dependencies': [
+-        '<(node_lib_target_name)',
+-        'deps/base64/base64.gyp:base64',
+-        'deps/googletest/googletest.gyp:gtest',
+-        'deps/googletest/googletest.gyp:gtest_main',
+-        'deps/histogram/histogram.gyp:histogram',
+-        'deps/uvwasi/uvwasi.gyp:uvwasi',
+-        'node_dtrace_header',
+-        'node_dtrace_ustack',
+-        'node_dtrace_provider',
+-      ],
+-
+-      'includes': [
+-        'node.gypi'
+-      ],
+-
+-      'include_dirs': [
+-        'src',
+-        'tools/msvs/genfiles',
+-        'deps/v8/include',
+-        'deps/cares/include',
+-        'deps/uv/include',
+-        'deps/uvwasi/include',
+-        'test/cctest',
+-      ],
+-
+-      'defines': [
+-        'NODE_ARCH="<(target_arch)"',
+-        'NODE_PLATFORM="<(OS)"',
+-        'NODE_WANT_INTERNALS=1',
+-      ],
+-
+-      'sources': [
+-        'src/node_snapshot_stub.cc',
+-        'src/node_code_cache_stub.cc',
+-        'test/cctest/node_test_fixture.cc',
+-        'test/cctest/node_test_fixture.h',
+-        'test/cctest/test_aliased_buffer.cc',
+-        'test/cctest/test_base64.cc',
+-        'test/cctest/test_base_object_ptr.cc',
+-        'test/cctest/test_node_postmortem_metadata.cc',
+-        'test/cctest/test_environment.cc',
+-        'test/cctest/test_js_native_api_v8.cc',
+-        'test/cctest/test_linked_binding.cc',
+-        'test/cctest/test_node_api.cc',
+-        'test/cctest/test_per_process.cc',
+-        'test/cctest/test_platform.cc',
+-        'test/cctest/test_report.cc',
+-        'test/cctest/test_json_utils.cc',
+-        'test/cctest/test_sockaddr.cc',
+-        'test/cctest/test_traced_value.cc',
+-        'test/cctest/test_util.cc',
+-        'test/cctest/test_url.cc',
+-      ],
+-
+-      'conditions': [
+-        [ 'node_use_openssl=="true"', {
+-          'defines': [
+-            'HAVE_OPENSSL=1',
+-          ],
+-          'sources': [
+-            'test/cctest/test_crypto_clienthello.cc',
+-            'test/cctest/test_node_crypto.cc',
+-          ]
+-        }],
+-        ['v8_enable_inspector==1', {
+-          'sources': [
+-            'test/cctest/test_inspector_socket.cc',
+-            'test/cctest/test_inspector_socket_server.cc'
+-          ],
+-          'defines': [
+-            'HAVE_INSPECTOR=1',
+-          ],
+-        }, {
+-           'defines': [
+-             'HAVE_INSPECTOR=0',
+-           ]
+-        }],
+-        ['OS=="solaris"', {
+-          'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
+-        }],
+-        # Skip cctest while building shared lib node for Windows
+-        [ 'OS=="win" and node_shared=="true"', {
+-          'type': 'none',
+-        }],
+-        [ 'node_shared=="true"', {
+-          'xcode_settings': {
+-            'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', ],
+-          },
+-        }],
+-        ['OS=="win"', {
+-          'libraries': [
+-            'Dbghelp.lib',
+-            'winmm.lib',
+-            'Ws2_32.lib',
+-          ],
+-        }],
+-      ],
+-    }, # cctest
+-
+-    {
+-      'target_name': 'embedtest',
+-      'type': 'executable',
+-
+-      'dependencies': [
+-        '<(node_lib_target_name)',
+-        'deps/histogram/histogram.gyp:histogram',
+-        'deps/uvwasi/uvwasi.gyp:uvwasi',
+-        'node_dtrace_header',
+-        'node_dtrace_ustack',
+-        'node_dtrace_provider',
+-      ],
+-
+-      'includes': [
+-        'node.gypi'
+-      ],
+-
+-      'include_dirs': [
+-        'src',
+-        'tools/msvs/genfiles',
+-        'deps/v8/include',
+-        'deps/cares/include',
+-        'deps/uv/include',
+-        'deps/uvwasi/include',
+-        'test/embedding',
+-      ],
+-
+-      'sources': [
+-        'src/node_snapshot_stub.cc',
+-        'src/node_code_cache_stub.cc',
+-        'test/embedding/embedtest.cc',
+-      ],
+-
+-      'conditions': [
+-        ['OS=="solaris"', {
+-          'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
+-        }],
+-        # Skip cctest while building shared lib node for Windows
+-        [ 'OS=="win" and node_shared=="true"', {
+-          'type': 'none',
+-        }],
+-        [ 'node_shared=="true"', {
+-          'xcode_settings': {
+-            'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', ],
+-          },
+-        }],
+-        ['OS=="win"', {
+-          'libraries': [
+-            'Dbghelp.lib',
+-            'winmm.lib',
+-            'Ws2_32.lib',
+-          ],
+-        }],
+-      ],
+-    }, # embedtest
+ 
+     {
+       'target_name': 'overlapped-checker',
+@@ -1363,59 +1205,13 @@
+             'Ws2_32.lib',
+           ],
+         }],
+-      ],
+-    }, # mkcodecache
+-    {
+-      'target_name': 'node_mksnapshot',
+-      'type': 'executable',
+-
+-      'dependencies': [
+-        '<(node_lib_target_name)',
+-        'deps/histogram/histogram.gyp:histogram',
+-        'deps/uvwasi/uvwasi.gyp:uvwasi',
+-      ],
+-
+-      'includes': [
+-        'node.gypi'
+-      ],
+-
+-      'include_dirs': [
+-        'src',
+-        'tools/msvs/genfiles',
+-        'deps/v8/include',
+-        'deps/cares/include',
+-        'deps/uv/include',
+-        'deps/uvwasi/include',
+-      ],
+-
+-      'defines': [ 'NODE_WANT_INTERNALS=1' ],
+-
+-      'sources': [
+-        'src/node_snapshot_stub.cc',
+-        'src/node_code_cache_stub.cc',
+-        'tools/snapshot/node_mksnapshot.cc',
+-      ],
+-
+-      'conditions': [
+-        [ 'node_use_openssl=="true"', {
+-          'defines': [
+-            'HAVE_OPENSSL=1',
+-          ],
+-        }],
+-        ['v8_enable_inspector==1', {
+-          'defines': [
+-            'HAVE_INSPECTOR=1',
+-          ],
+-        }],
+-        ['OS=="win"', {
++        ['target_arch=="ia32"', {
+           'libraries': [
+-            'Dbghelp.lib',
+-            'winmm.lib',
+-            'Ws2_32.lib',
++            '-latomic',
+           ],
+         }],
+       ],
+-    }, # node_mksnapshot
++    }, # mkcodecache
+   ], # end targets
+ 
+   'conditions': [

--- a/tur/nodejs-16/src-debug_utils.cc.patch
+++ b/tur/nodejs-16/src-debug_utils.cc.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/src/debug_utils.cc node-v16.14.2/src/debug_utils.cc
+--- node-v16.14.2.orig/src/debug_utils.cc	2022-03-18 15:06:23.901091188 +0530
++++ node-v16.14.2/src/debug_utils.cc	2022-03-18 15:08:50.991091132 +0530
+@@ -500,7 +500,7 @@
+ 
+   WriteConsoleW(handle, wbuf.data(), n, nullptr, nullptr);
+   return;
+-#elif defined(__ANDROID__)
++#elif defined(__ANDROID__) && !defined(__TERMUX__)
+   if (file == stderr) {
+     __android_log_print(ANDROID_LOG_ERROR, "nodejs", "%s", str.data());
+     return;

--- a/tur/nodejs-16/src-node_internals.h.patch
+++ b/tur/nodejs-16/src-node_internals.h.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/src/node_internals.h node-v16.14.2/src/node_internals.h
+--- node-v16.14.2.orig/src/node_internals.h	2022-03-18 15:06:23.951091188 +0530
++++ node-v16.14.2/src/node_internals.h	2022-03-18 15:08:53.321091131 +0530
+@@ -281,7 +281,7 @@
+ 
+ // Functions defined in node.cc that are exposed via the bootstrapper object
+ 
+-#if defined(__POSIX__) && !defined(__ANDROID__) && !defined(__CloudABI__)
++#if defined(__POSIX__) && !defined(__CloudABI__)
+ #define NODE_IMPLEMENTS_POSIX_CREDENTIALS 1
+ #endif  // defined(__POSIX__) && !defined(__ANDROID__) && !defined(__CloudABI__)
+ 

--- a/tur/nodejs-16/src-node_main.cc.patch
+++ b/tur/nodejs-16/src-node_main.cc.patch
@@ -1,0 +1,14 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/src/node_main.cc node-v16.14.2/src/node_main.cc
+--- node-v16.14.2.orig/src/node_main.cc	2022-03-18 15:06:23.951091188 +0530
++++ node-v16.14.2/src/node_main.cc	2022-03-18 15:08:55.611091130 +0530
+@@ -124,6 +124,10 @@
+   // calls elsewhere in the program (e.g., any logging from V8.)
+   setvbuf(stdout, nullptr, _IONBF, 0);
+   setvbuf(stderr, nullptr, _IONBF, 0);
++  if(getenv("TMPDIR") == NULL) {
++    // Give javascript programs (such as updated versions of npm) a working tmpdir.
++    putenv("TMPDIR=@TERMUX_PREFIX@/tmp");
++  }
+   return node::Start(argc, argv);
+ }
+ #endif

--- a/tur/nodejs-16/src-node_report.cc.patch
+++ b/tur/nodejs-16/src-node_report.cc.patch
@@ -1,0 +1,12 @@
+--- ./src/node_report.cc	2022-09-23 08:19:19.000000000 +0530
++++ ./src/node_report.cc.mod	2022-10-06 21:25:11.127454780 +0530
+@@ -425,6 +425,9 @@
+     }
+     writer->json_arrayend();
+     uv_free_cpu_info(cpu_info, count);
++  } else {
++    writer->json_arraystart("cpus");
++    writer->json_arrayend();
+   }
+ }
+ 

--- a/tur/nodejs-16/test-parallel-test-blob-buffer-too-large.js.patch
+++ b/tur/nodejs-16/test-parallel-test-blob-buffer-too-large.js.patch
@@ -1,0 +1,17 @@
+--- ./test/parallel/test-blob-buffer-too-large.js.orig	2022-06-05 08:43:15.647600971 +0530
++++ ./test/parallel/test-blob-buffer-too-large.js	2022-06-05 08:55:58.717600680 +0530
+@@ -4,10 +4,14 @@
+ const common = require('../common');
+ const assert = require('assert');
+ const { Blob } = require('buffer');
++const { platform } = require('os');
+ 
+ if (common.isFreeBSD)
+   common.skip('Oversized buffer make the FreeBSD CI runner crash');
+ 
++if (platform() === 'android')
++  common.skip('Android will kill heavy memory using processes sometimes crashing Termux');
++
+ try {
+   new Blob([new Uint8Array(0xffffffff), [1]]);
+ } catch (e) {

--- a/tur/nodejs-16/test-parallel-test-child-process-exec-env.js.patch
+++ b/tur/nodejs-16/test-parallel-test-child-process-exec-env.js.patch
@@ -1,0 +1,11 @@
+--- ./test/parallel/test-child-process-exec-env.js.orig	2022-06-05 08:57:52.717600637 +0530
++++ ./test/parallel/test-child-process-exec-env.js	2022-06-05 09:02:24.887600533 +0530
+@@ -44,7 +44,7 @@
+ }
+ 
+ if (!isWindows) {
+-  child = exec('/usr/bin/env', { env: { 'HELLO': 'WORLD' } }, after);
++  child = exec('@TERMUX_PREFIX@/bin/env', { env: { 'HELLO': 'WORLD' } }, after);
+ } else {
+   child = exec('set',
+                { env: { ...process.env, 'HELLO': 'WORLD' } },

--- a/tur/nodejs-16/test-parallel-test-child-process-spawnsync-shell.js.patch
+++ b/tur/nodejs-16/test-parallel-test-child-process-spawnsync-shell.js.patch
@@ -1,0 +1,11 @@
+--- ./test/parallel/test-child-process-spawnsync-shell.js.orig	2022-06-05 08:34:30.587601172 +0530
++++ ./test/parallel/test-child-process-spawnsync-shell.js	2022-06-05 08:34:48.497601165 +0530
+@@ -82,7 +82,7 @@
+   test('darwin', '/bin/csh', '/bin/csh');
+ 
+   // Test Android platforms.
+-  test('android', true, '/system/bin/sh');
++  test('android', true, '@TERMUX_PREFIX@/bin/sh');
+ 
+   // Test Windows platforms with a user specified shell.
+   test('win32', 'powershell.exe', 'powershell.exe');

--- a/tur/nodejs-16/test-parallel-test-child-process-stdio-overlapped.js.patch
+++ b/tur/nodejs-16/test-parallel-test-child-process-stdio-overlapped.js.patch
@@ -1,0 +1,17 @@
+--- ./test/parallel/test-child-process-stdio-overlapped.js.orig	2022-06-05 09:57:50.337599264 +0530
++++ ./test/parallel/test-child-process-stdio-overlapped.js	2022-06-05 10:12:13.197598935 +0530
+@@ -28,10 +28,13 @@
+ const assert = require('assert');
+ const path = require('path');
+ const child_process = require('child_process');
++const { mkdtempSync } = require('fs')
+ 
+ const exeExtension = process.platform === 'win32' ? '.exe' : '';
+ const exe = 'overlapped-checker' + exeExtension;
+-const exePath = path.join(path.dirname(process.execPath), exe);
++const exePath = path.join(mkdtempSync(process.env.TMPDIR + '/' || '@TERMUX_PREFIX@/tmp/'), exe);
++
++child_process.spawnSync('clang', ['-O3', 'test/overlapped-checker/main_unix.c', '-o', exePath]);
+ 
+ const child = child_process.spawn(exePath, [], {
+   stdio: ['overlapped', 'pipe', 'pipe']

--- a/tur/nodejs-16/test-parallel-test-dgram-bind-fd.js.patch
+++ b/tur/nodejs-16/test-parallel-test-dgram-bind-fd.js.patch
@@ -1,0 +1,19 @@
+--- ./test/parallel/test-dgram-bind-fd.js.orig	2022-06-05 10:30:47.907598510 +0530
++++ ./test/parallel/test-dgram-bind-fd.js	2022-06-05 10:31:18.697598498 +0530
+@@ -7,6 +7,7 @@
+ const assert = require('assert');
+ const dgram = require('dgram');
+ const { internalBinding } = require('internal/test/binding');
++const { platform } = require('os');
+ const { UDP } = internalBinding('udp_wrap');
+ const { UV_UDP_REUSEADDR } = require('os').constants;
+ 
+@@ -77,7 +78,7 @@
+         const sendBufferSize = socket.getSendBufferSize();
+ 
+         // note: linux will double the buffer size
+-        const expectedBufferSize = common.isLinux ?
++        const expectedBufferSize = (common.isLinux || platform() === 'android') ?
+           BUFFER_SIZE * 2 : BUFFER_SIZE;
+         assert.strictEqual(recvBufferSize, expectedBufferSize);
+         assert.strictEqual(sendBufferSize, expectedBufferSize);

--- a/tur/nodejs-16/test-parallel-test-dgram-membership.js.patch
+++ b/tur/nodejs-16/test-parallel-test-dgram-membership.js.patch
@@ -1,0 +1,40 @@
+--- ./test/parallel/test-dgram-membership.js.orig	2022-06-05 10:44:44.687598191 +0530
++++ ./test/parallel/test-dgram-membership.js	2022-06-05 10:46:16.867598156 +0530
+@@ -3,6 +3,7 @@
+ const common = require('../common');
+ const assert = require('assert');
+ const dgram = require('dgram');
++const { platform } = require('os');
+ const multicastAddress = '224.0.0.114';
+ 
+ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
+@@ -106,11 +107,12 @@
+ // addSourceSpecificMembership with invalid groupAddress should throw
+ {
+   const socket = setup();
++  const errCode = platform() === 'android' ? 'ENOSYS' : 'EINVAL';
+   assert.throws(() => {
+     socket.addSourceSpecificMembership(multicastAddress, '0');
+   }, {
+-    code: 'EINVAL',
+-    message: 'addSourceSpecificMembership EINVAL'
++    code: errCode,
++    message: `addSourceSpecificMembership ${errCode}`
+   });
+   socket.close();
+ }
+@@ -144,11 +146,12 @@
+ // dropSourceSpecificMembership with invalid UDP should throw
+ {
+   const socket = setup();
++  const errCode = platform() === 'android' ? 'ENOSYS' : 'EINVAL';
+   assert.throws(() => {
+     socket.dropSourceSpecificMembership(multicastAddress, '0');
+   }, {
+-    code: 'EINVAL',
+-    message: 'dropSourceSpecificMembership EINVAL'
++    code: errCode,
++    message: `dropSourceSpecificMembership ${errCode}`
+   });
+   socket.close();
+ }

--- a/tur/nodejs-16/test-parallel-test-dgram-socket-buffer-size.js.patch
+++ b/tur/nodejs-16/test-parallel-test-dgram-socket-buffer-size.js.patch
@@ -1,0 +1,19 @@
+--- ./test/parallel/test-dgram-socket-buffer-size.js.orig	2022-06-05 10:48:41.037598101 +0530
++++ ./test/parallel/test-dgram-socket-buffer-size.js	2022-06-05 10:48:52.537598096 +0530
+@@ -6,6 +6,7 @@
+ const dgram = require('dgram');
+ const { inspect } = require('util');
+ const { internalBinding } = require('internal/test/binding');
++const { platform } = require('os');
+ const {
+   UV_EBADF,
+   UV_EINVAL,
+@@ -115,7 +116,7 @@
+     socket.setSendBufferSize(10000);
+ 
+     // note: linux will double the buffer size
+-    const expectedBufferSize = common.isLinux ? 20000 : 10000;
++    const expectedBufferSize = (common.isLinux || platform() === 'android') ? 20000 : 10000;
+     assert.strictEqual(socket.getRecvBufferSize(), expectedBufferSize);
+     assert.strictEqual(socket.getSendBufferSize(), expectedBufferSize);
+     socket.close();

--- a/tur/nodejs-16/test-parallel-test-gc-http-client-connaborted.js.patch
+++ b/tur/nodejs-16/test-parallel-test-gc-http-client-connaborted.js.patch
@@ -1,0 +1,11 @@
+--- ./test/parallel/test-gc-http-client-connaborted.js.orig	2022-06-05 08:39:51.327601049 +0530
++++ ./test/parallel/test-gc-http-client-connaborted.js	2022-06-05 08:40:14.897601040 +0530
+@@ -8,7 +8,7 @@
+ const http = require('http');
+ const os = require('os');
+ 
+-const cpus = os.cpus().length;
++const cpus = 8;
+ let createClients = true;
+ let done = 0;
+ let count = 0;

--- a/tur/nodejs-16/test-parallel-test-process-constants-noatime.js.patch
+++ b/tur/nodejs-16/test-parallel-test-process-constants-noatime.js.patch
@@ -1,0 +1,11 @@
+--- ./test/parallel/test-process-constants-noatime.js.orig	2022-06-21 15:34:16.647265960 +0530
++++ ./test/parallel/test-process-constants-noatime.js	2022-06-21 15:34:38.957265951 +0530
+@@ -4,7 +4,7 @@
+ const assert = require('assert');
+ const constants = require('fs').constants;
+ 
+-if (common.isLinux) {
++if (common.isLinux || process.platform === 'android') {
+   assert('O_NOATIME' in constants);
+   assert.strictEqual(constants.O_NOATIME, 0x40000);
+ } else {

--- a/tur/nodejs-16/test-sequential-test-gc-http-client-onerror.js.patch
+++ b/tur/nodejs-16/test-sequential-test-gc-http-client-onerror.js.patch
@@ -1,0 +1,11 @@
+--- ./test/sequential/test-gc-http-client-onerror.js.orig	2022-06-05 10:18:02.427598802 +0530
++++ ./test/sequential/test-gc-http-client-onerror.js	2022-06-05 10:18:17.627598796 +0530
+@@ -6,7 +6,7 @@
+ const common = require('../common');
+ const onGC = require('../common/ongc');
+ 
+-const cpus = require('os').cpus().length;
++const cpus = 8;
+ 
+ function serverHandler(req, res) {
+   req.resume();

--- a/tur/nodejs-16/test-sequential-test-gc-http-client.js.patch
+++ b/tur/nodejs-16/test-sequential-test-gc-http-client.js.patch
@@ -1,0 +1,11 @@
+--- ./test/sequential/test-gc-http-client.js.orig	2022-06-05 10:17:44.127598809 +0530
++++ ./test/sequential/test-gc-http-client.js	2022-06-05 10:17:53.947598805 +0530
+@@ -5,7 +5,7 @@
+ const common = require('../common');
+ const onGC = require('../common/ongc');
+ 
+-const cpus = require('os').cpus().length;
++const cpus = 8;
+ 
+ function serverHandler(req, res) {
+   res.writeHead(200, { 'Content-Type': 'text/plain' });

--- a/tur/nodejs-16/tools-v8_gypfiles-toolchain.gypi.patch
+++ b/tur/nodejs-16/tools-v8_gypfiles-toolchain.gypi.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/tools/v8_gypfiles/toolchain.gypi node-v16.14.2/tools/v8_gypfiles/toolchain.gypi
+--- node-v16.14.2.orig/tools/v8_gypfiles/toolchain.gypi	2022-03-18 15:06:28.221091186 +0530
++++ node-v16.14.2/tools/v8_gypfiles/toolchain.gypi	2022-03-18 15:08:57.961091129 +0530
+@@ -62,7 +62,7 @@
+     'mips_use_msa%': 0,
+ 
+     # Print to stdout on Android.
+-    'v8_android_log_stdout%': 0,
++    'v8_android_log_stdout%': 1,
+ 
+     'v8_enable_backtrace%': 0,
+ 

--- a/tur/nodejs-16/tools-v8_gypfiles-v8.gyp.patch
+++ b/tur/nodejs-16/tools-v8_gypfiles-v8.gyp.patch
@@ -1,0 +1,25 @@
+diff '--color=auto' -uNr node-v16.14.2.orig/tools/v8_gypfiles/v8.gyp node-v16.14.2/tools/v8_gypfiles/v8.gyp
+--- node-v16.14.2.orig/tools/v8_gypfiles/v8.gyp	2022-03-18 15:06:28.221091186 +0530
++++ node-v16.14.2/tools/v8_gypfiles/v8.gyp	2022-03-18 15:09:00.361091128 +0530
+@@ -1121,6 +1121,7 @@
+             '<(V8_ROOT)/src/base/platform/platform-posix.h',
+             '<(V8_ROOT)/src/base/platform/platform-posix-time.cc',
+             '<(V8_ROOT)/src/base/platform/platform-posix-time.h',
++	    '<(V8_ROOT)/src/base/platform/platform-linux.h',
+           ],
+           'link_settings': {
+             'target_conditions': [
+@@ -1628,7 +1629,12 @@
+           }],
+           ['clang or OS!="win"', {
+             'conditions': [
+-              ['_toolset == "host" and host_arch == "x64" or _toolset == "target" and target_arch=="x64"', {
++              ['_toolset == "host" and host_arch == "x64" and (target_arch == "arm" or target_arch == "ia32")', {
++                'sources': [
++                  '<(V8_ROOT)/src/heap/base/asm/ia32/push_registers_asm.cc',
++                ],
++              }],
++              ['_toolset == "host" and host_arch == "x64" and (target_arch == "x64" or target_arch == "arm64") or (_toolset == "target" and target_arch == "x64")', {
+                 'sources': [
+                   '<(V8_ROOT)/src/heap/base/asm/x64/push_registers_asm.cc',
+                 ],


### PR DESCRIPTION
Main repository will let `node-18` provide the default `nodejs-lts`, but `code-server` prefers to use `node-16`.