### PR TITLE
Use rust nightly from release 

### DIFF
--- a/tur/rustc-nightly/build.sh
+++ b/tur/rustc-nightly/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.rust-lang.org
 TERMUX_PKG_DESCRIPTION="Rust compiler and utilities (nightly version)"
 TERMUX_PKG_DEPENDS="libc++, clang, openssl, lld, zlib, libllvm"
 TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_REVISION=2
 _DATE="2023-02-27"
 TERMUX_PKG_VERSION="1.67.1-${_DATE//-/.}-nightly"

--- a/tur/rustc-nightly/build.sh
+++ b/tur/rustc-nightly/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="Rust compiler and utilities (nightly version)"
 TERMUX_PKG_DEPENDS="libc++, clang, openssl, lld, zlib, libllvm"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_REVISION=2
-TERMUX_PKG_MAINTAINER="@termux-user-repository"
-TERMUX_PKG_VERSION="1.67.1-nightly"
-TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-nightly-src.tar.xz
-TERMUX_PKG_SHA256=345395db595fdd79ce651e587d86cc0f81b7b60a5507c3ec4fa32b19cf99bc4f
+_DATE="2023-02-27"
+TERMUX_PKG_VERSION="1.67.1-${_DATE//-/.}-nightly"
+TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/$_DATE/rustc-nightly-src.tar.xz
+TERMUX_PKG_SHA256=ceb53d6a8cc18434efa3093e3debe5484dde8201dcba4fdbe83e83f32b8dad74
 TERMUX_PKG_RM_AFTER_INSTALL="bin/llvm-* bin/llc bin/opt"
 
 termux_step_pre_configure() {

--- a/tur/rustc-nightly/build.sh
+++ b/tur/rustc-nightly/build.sh
@@ -6,7 +6,7 @@ TERMUX_PKG_REVISION=2
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="1.67.1-nightly"
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-nightly-src.tar.xz
-TERMUX_PKG_SHA256=ceb53d6a8cc18434efa3093e3debe5484dde8201dcba4fdbe83e83f32b8dad74
+TERMUX_PKG_SHA256=345395db595fdd79ce651e587d86cc0f81b7b60a5507c3ec4fa32b19cf99bc4f
 TERMUX_PKG_RM_AFTER_INSTALL="bin/llvm-* bin/llc bin/opt"
 
 termux_step_pre_configure() {

--- a/tur/rustc-nightly/build.sh
+++ b/tur/rustc-nightly/build.sh
@@ -3,9 +3,8 @@ TERMUX_PKG_DESCRIPTION="Rust compiler and utilities (nightly version)"
 TERMUX_PKG_DEPENDS="libc++, clang, openssl, lld, zlib, libllvm"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
-_DATE="2023-02-27"
-TERMUX_PKG_VERSION="1.67.1-${_DATE//-/.}-nightly"
-TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/$_DATE/rustc-nightly-src.tar.xz
+TERMUX_PKG_VERSION="1.67.1-nightly"
+TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-nightly-src.tar.xz
 TERMUX_PKG_SHA256=ceb53d6a8cc18434efa3093e3debe5484dde8201dcba4fdbe83e83f32b8dad74
 TERMUX_PKG_RM_AFTER_INSTALL="bin/llvm-* bin/llc bin/opt"
 

--- a/tur/rustc-nightly/build.sh
+++ b/tur/rustc-nightly/build.sh
@@ -2,6 +2,7 @@ TERMUX_PKG_HOMEPAGE=https://www.rust-lang.org
 TERMUX_PKG_DESCRIPTION="Rust compiler and utilities (nightly version)"
 TERMUX_PKG_DEPENDS="libc++, clang, openssl, lld, zlib, libllvm"
 TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="1.67.1-nightly"
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/rustc-nightly-src.tar.xz

--- a/tur/rustc-nightly/rust-src-nightly.subpackage.sh
+++ b/tur/rustc-nightly/rust-src-nightly.subpackage.sh
@@ -1,3 +1,7 @@
 TERMUX_SUBPKG_DESCRIPTION="rust src"
 TERMUX_SUBPKG_PLATFORM_INDEPENDENT=true
 TERMUX_SUBPKG_INCLUDE="opt/rust-nightly/lib/rustlib/src"
+_DATE="2023-02-27"
+TERMUX_PKG_VERSION="1.67.1-${_DATE//-/.}-nightly"
+TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/$_DATE/rustc-nightly-src.tar.xz
+TERMUX_PKG_SHA256=ceb53d6a8cc18434efa3093e3debe5484dde8201dcba4fdbe83e83f32b8dad74


### PR DESCRIPTION
Use rust official release instead of src date based.

It can lead to issue between rustc and rust src if they haven't pulled from GH. 

