### PR TITLE
add(tur): blender deps

### DIFF
--- a/tur/libraw/build.sh
+++ b/tur/libraw/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://www.libraw.org
+TERMUX_PKG_DESCRIPTION="A library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others"
+TERMUX_PKG_LICENSE="LGPL-2.1, CDDL-1.1"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=0.21.1
+TERMUX_PKG_SRCURL=https://www.libraw.org/data/LibRaw-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=630a6bcf5e65d1b1b40cdb8608bdb922316759bfb981c65091fec8682d1543cd
+TERMUX_PKG_DEPENDS="littlecms, libjasper"
+
+termux_step_pre_configure() {
+    LDFLAGS+=" $($CC -print-libgcc-file-name)"
+}

--- a/tur/libspnav/build.sh
+++ b/tur/libspnav/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/FreeSpacenav/libspnav
+TERMUX_PKG_DESCRIPTION="Library for communicating with spacenavd or 3dxsrv to get input from 6-dof devices"
+TERMUX_PKG_LICENSE="BSD 3-Clause"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=1.0
+TERMUX_PKG_SRCURL=https://github.com/FreeSpacenav/libspnav/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=8849b7f7826d750f6956cf8f4f53937f2359ab6da97d6c834c71d5f771212e7c
+TERMUX_PKG_DEPENDS="libx11"
+TERMUX_PKG_BUILD_IN_SRC=true

--- a/tur/libspnav/makefile.patch
+++ b/tur/libspnav/makefile.patch
@@ -1,0 +1,13 @@
+--- libspnav-1.0/Makefile.in	2022-04-01 08:34:40.000000000 +0530
++++ libspnav-1.0.mod/Makefile.in	2022-09-26 06:46:18.141136456 +0530
+@@ -5,8 +5,8 @@
+ name = spnav
+ lib_a = lib$(name).a
+
+-incpaths = -I. -I/usr/local/include -I/usr/X11R6/include
+-libpaths = -L/usr/local/lib -L/usr/X11R6/lib
++incpaths = -I. -I@TERMUX_PREFIX@/include
++libpaths = -L@TERMUX_PREFIX@/lib
+
+ CC ?= gcc
+ AR ?= ar

--- a/tur/openimageio/build.sh
+++ b/tur/openimageio/build.sh
@@ -1,0 +1,15 @@
+TERMUX_PKG_HOMEPAGE=http://www.openimageio.org/
+TERMUX_PKG_DESCRIPTION="A library for reading and writing images, including classes, utilities, and applications"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="LICENSE.md"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=2.4.9.0
+TERMUX_PKG_SRCURL=https://github.com/OpenImageIO/oiio/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=d04c12575d63d13ed64fc037ea37da616224736213d785de9f50337f6eb5a9ed
+TERMUX_PKG_DEPENDS="openexr, boost-headers, openjpeg, glew, libtiff, opencolorio, libwebp, libpng, libheif, libhdf5, freetype, python, ffmpeg, opencv, ptex-static, qt5-qtbase, pybind11, libraw"
+TERMUX_PKG_BUILD_DEPENDS="mesa, fontconfig, libxrender, robin-map, fmt, libpugixml"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DUSE_PYTHON=ON
+-DPYTHON_VERSION=3.11
+-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
+"

--- a/tur/openimageio/disable-neon.patch
+++ b/tur/openimageio/disable-neon.patch
@@ -1,0 +1,24 @@
+From 83df74ff4a39712b7853270cdc25e404f1b5097f Mon Sep 17 00:00:00 2001
+From: Kevin Mihelich <kevin@archlinuxarm.org>
+Date: Fri, 2 Oct 2020 11:10:28 -0600
+Subject: [PATCH] disable neon
+
+---
+ src/include/OpenImageIO/simd.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/include/OpenImageIO/simd.h b/src/include/OpenImageIO/simd.h
+index f82f8786..dd983580 100644
+--- a/src/include/OpenImageIO/simd.h
++++ b/src/include/OpenImageIO/simd.h
+@@ -206,7 +206,7 @@
+ #  define OIIO_F16C_ENABLED 0
+ #endif
+ 
+-#if defined(__ARM_NEON__) && !defined(OIIO_NO_NEON)
++#if 0 && defined(__ARM_NEON__) && !defined(OIIO_NO_NEON)
+ #  define OIIO_SIMD 4
+ #  define OIIO_SIMD_NEON 1
+ #  define OIIO_SIMD_MAX_SIZE_BYTES 16
+-- 
+2.36.1

--- a/tur/openimageio/prefix.patch
+++ b/tur/openimageio/prefix.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -uNr oiio-2.4.9.0/src/libOpenImageIO/imagebufalgo_draw.cpp oiio-2.4.9.0.mod/src/libOpenImageIO/imagebufalgo_draw.cpp
+--- oiio-2.4.9.0/src/libOpenImageIO/imagebufalgo_draw.cpp	2023-03-01 23:22:37.000000000 +0530
++++ oiio-2.4.9.0.mod/src/libOpenImageIO/imagebufalgo_draw.cpp	2023-03-08 10:07:47.167466610 +0530
+@@ -821,7 +821,7 @@
+             Sysutil::getenv("OPENIMAGEIOHOME"));  // DEPRECATED(1.9)
+         fontpath_add_from_dir("/Library");
+         fontpath_add_from_dir("C:/Windows");
+-        fontpath_add_from_dir("/usr");
++        fontpath_add_from_dir("@TERMUX_PREFIX");
+         fontpath_add_from_dir("/usr/local");
+         fontpath_add_from_dir("/opt/local");
+         std::string this_program = OIIO::Sysutil::this_program_path();

--- a/tur/openvdb/build.sh
+++ b/tur/openvdb/build.sh
@@ -1,0 +1,17 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/dreamworksanimation/openvdb
+TERMUX_PKG_DESCRIPTION="A large suite of tools for the efficient storage and manipulation of sparse volumetric data discretized on three-dimensional grids"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=10.0.1
+TERMUX_PKG_SRCURL=https://github.com/dreamworksanimation/openvdb/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=887a3391fbd96b20c77914f4fb3ab4b33d26e5fc479aa036d395def5523c622f
+TERMUX_PKG_DEPENDS="boost, libtbb, zlib, libblosc"
+TERMUX_PKG_BUILD_DEPENDS="mesa, glfw, glu"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DUSE_NUMPY=OFF
+-DUSE_LOG4CPLUS=OFF
+-DOPENVDB_BUILD_PYTHON_MODULE=OFf
+-DOPENVDB_BUILD_DOCS=OFF
+-DOPENVDB_BUILD_UNITTESTS=OFF
+"

--- a/tur/pybind11/build.sh
+++ b/tur/pybind11/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://pybind11.readthedocs.org
+TERMUX_PKG_DESCRIPTION="A lightweight header-only library that exposes C++ types in Python and vice versa"
+TERMUX_PKG_LICENSE="BSD"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="2.10.3"
+TERMUX_PKG_SRCURL=https://github.com/pybind/pybind11/archive/v${TERMUX_PKG_VERSION}/pybind11-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=5d8c4c5dda428d3a944ba3d2a5212cb988c2fae4670d58075a5a49075a6ca315
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="python"
+TERMUX_PKG_BUILD_DEPENDS="boost, eigen"
+TERMUX_PKG_PYTHON_COMMON_DEPS="setuptools"
+TERMUX_CMAKE_BUILD="Unix Makefiles"


### PR DESCRIPTION
As Blender does not support cross-compiling, I decided to use Tur-on-device. In order to build Blender, I need these dependencies, as they would not be accepted in termux-packages.
