### PR TITLE
perl-net-ssleay: bump after perl update

### DIFF
--- a/tur-on-device/perl-net-ssleay/build.sh
+++ b/tur-on-device/perl-net-ssleay/build.sh
@@ -10,5 +10,5 @@ TERMUX_PKG_DEPENDS="perl, openssl"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_configure() {
-	perl Makefile.PL PREFIX=$TERMUX_PREFIX
+	OPENSSL_PREFIX=$TERMUX_PREFIX perl Makefile.PL PREFIX=$TERMUX_PREFIX
 }

--- a/tur-on-device/perl-net-ssleay/build.sh
+++ b/tur-on-device/perl-net-ssleay/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Perl bindings for OpenSSL and LibreSSL"
 TERMUX_PKG_LICENSE="Artistic-License-2.0"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION=1.92
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/radiator-software/p5-net-ssleay/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=0f502c1c10884a31699ac0d58d01d6cb4ca18ae59cf626b16d3327f7eb952ca9
 TERMUX_PKG_DEPENDS="perl, openssl"


### PR DESCRIPTION
So that perl-net-ssleay installs to `$PREFIX/lib/perl5/5.36.1` where the other perl stuff currently resides.