### PR TITLE
New package ffmpeg 5.1.2

### DIFF
--- a/tur/ffmpeg5.1/build.sh
+++ b/tur/ffmpeg5.1/build.sh
@@ -1,0 +1,89 @@
+TERMUX_PKG_HOMEPAGE=https://ffmpeg.org
+TERMUX_PKG_DESCRIPTION="Tools and libraries to manipulate a wide range of multimedia formats and protocols"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=5.1.2
+TERMUX_PKG_SRCURL=https://www.ffmpeg.org/releases/ffmpeg-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=619e706d662c8420859832ddc259cd4d4096a48a2ce1eefd052db9e440eef3dc
+TERMUX_PKG_DEPENDS="freetype, game-music-emu, libaom, libandroid-glob, libass, libbluray, libbz2, libdav1d, libgnutls, libiconv, liblzma, libmp3lame, libopus, librav1e, libsoxr, libtheora, libvorbis, libvpx, libvidstab, libwebp, libx264, libx265, libxml2, xvidcore, zlib"
+TERMUX_PKG_CONFLICTS="libav"
+TERMUX_PKG_BREAKS="ffmpeg-dev"
+TERMUX_PKG_REPLACES="ffmpeg-dev"
+
+termux_step_configure() {
+	cd $TERMUX_PKG_BUILDDIR
+
+	_RPATH_FLAG="-Wl,-rpath=$TERMUX_PREFIX/lib"
+	_RPATH_FLAG_ADD="-Wl,-rpath=$TERMUX_PREFIX/opt/ffmpeg5.1/lib"
+	LDFLAGS="${LDFLAGS/$_RPATH_FLAG/$_RPATH_FLAG_ADD $_RPATH_FLAG}"
+
+	local _EXTRA_CONFIGURE_FLAGS=""
+	if [ $TERMUX_ARCH = "arm" ]; then
+		_ARCH="armeabi-v7a"
+		_EXTRA_CONFIGURE_FLAGS="--enable-neon"
+	elif [ $TERMUX_ARCH = "i686" ]; then
+		_ARCH="x86"
+		# Specify --disable-asm to prevent text relocations on i686,
+		# see https://trac.ffmpeg.org/ticket/4928
+		_EXTRA_CONFIGURE_FLAGS="--disable-asm"
+	elif [ $TERMUX_ARCH = "x86_64" ]; then
+		_ARCH="x86_64"
+	elif [ $TERMUX_ARCH = "aarch64" ]; then
+		_ARCH=$TERMUX_ARCH
+		_EXTRA_CONFIGURE_FLAGS="--enable-neon"
+	else
+		termux_error_exit "Unsupported arch: $TERMUX_ARCH"
+	fi
+
+	$TERMUX_PKG_SRCDIR/configure \
+		--prefix="$TERMUX_PREFIX/opt/ffmpeg5.1" \
+		--arch="${_ARCH}" \
+		--as="$AS" \
+		--cc="$CC" \
+		--cxx="$CXX" \
+		--nm="$NM" \
+		--pkg-config="$PKG_CONFIG" \
+		--strip="$STRIP" \
+		--cross-prefix="${TERMUX_HOST_PLATFORM}-" \
+		--disable-indevs \
+		--disable-outdevs \
+		--enable-indev=lavfi \
+		--disable-static \
+		--disable-symver \
+		--enable-cross-compile \
+		--enable-gnutls \
+		--enable-gpl \
+		--enable-libaom \
+		--enable-libass \
+		--enable-libbluray \
+		--enable-libdav1d \
+		--enable-libgme \
+		--enable-libmp3lame \
+		--enable-libfreetype \
+		--enable-libvorbis \
+		--enable-libopus \
+		--enable-librav1e \
+		--enable-libsoxr \
+		--enable-libx264 \
+		--enable-libx265 \
+		--enable-libxvid \
+		--enable-libvidstab \
+		--enable-libvpx \
+		--enable-libwebp \
+		--enable-libxml2 \
+		--enable-libtheora \
+		--enable-shared \
+		--target-os=android \
+		--extra-libs="-landroid-glob" \
+		--disable-vulkan \
+		$_EXTRA_CONFIGURE_FLAGS
+}
+
+termux_step_post_make_install() {
+	# Symlink binaries to $PREFIX/bin with version suffix
+	mkdir -p $TERMUX_PREFIX/bin
+	local f
+	for f in $TERMUX_PREFIX/opt/ffmpeg5.1/bin/*; do
+		ln -sfr $f $TERMUX_PREFIX/bin/"$(basename $f)"5.1
+	done
+}

--- a/tur/ffmpeg5.1/enable-soname-version.patch
+++ b/tur/ffmpeg5.1/enable-soname-version.patch
@@ -1,0 +1,12 @@
+--- a/configure
++++ b/configure
+@@ -5466,9 +5466,6 @@
+         enable section_data_rel_ro
+         add_cflags -fPIE
+         add_ldexeflags -fPIE -pie
+-        SLIB_INSTALL_NAME='$(SLIBNAME)'
+-        SLIB_INSTALL_LINKS=
+-        SHFLAGS='-shared -Wl,-soname,$(SLIBNAME)'
+         ;;
+     haiku)
+         prefix_default="/boot/common"

--- a/tur/ffmpeg5.1/libavutil-file_open.c.patch
+++ b/tur/ffmpeg5.1/libavutil-file_open.c.patch
@@ -1,0 +1,21 @@
+diff -uNr ffmpeg-4.1.1/libavutil/file_open.c ffmpeg-4.1.1.mod/libavutil/file_open.c
+--- ffmpeg-4.1.1/libavutil/file_open.c	2019-02-09 22:56:02.000000000 +0200
++++ ffmpeg-4.1.1.mod/libavutil/file_open.c	2019-03-02 01:54:58.775236751 +0200
+@@ -119,7 +119,7 @@
+ #undef free
+     free(ptr);
+ #else
+-    size_t len = strlen(prefix) + 12; /* room for "/tmp/" and "XXXXXX\0" */
++    size_t len = strlen(prefix) + strlen("@TERMUX_PREFIX@/tmp/") + 7; /* room for "@TERMUX_PREFIX@/tmp/" and "XXXXXX\0" */
+     *filename  = av_malloc(len);
+ #endif
+     /* -----common section-----*/
+@@ -136,7 +136,7 @@
+ #   endif
+     fd = open(*filename, O_RDWR | O_BINARY | O_CREAT | O_EXCL, 0600);
+ #else
+-    snprintf(*filename, len, "/tmp/%sXXXXXX", prefix);
++    snprintf(*filename, len, "@TERMUX_PREFIX@/tmp/%sXXXXXX", prefix);
+     fd = mkstemp(*filename);
+ #if defined(_WIN32) || defined (__ANDROID__)
+     if (fd < 0) {


### PR DESCRIPTION
FFmpeg 6.0 is in the Termux official repo:
https://github.com/termux/termux-packages/tree/master/packages/ffmpeg

 but PyAV currently doesn't build against FFmpeg 6.0 version due to removal of several deprecated features, including the flags AV_CODEC_CAP_TRUNCATED, AV_CODEC_CAP_AUTO_THREADS, AV_CODEC_CAP_INTRA_ONLY, AV_CODEC_CAP_LOSSLESS, and AVFMT_FLAG_PRIV_OPT.

The problem is reported in PyAV: 
https://github.com/PyAV-Org/PyAV/issues/1106

I'm adding ffmpeg 5.1.2 package to successfully build PyAV against it.

Thanks

