### PR TITLE
new package: python-fitsio

### DIFF
--- a/tur/python-fitsio/build.sh
+++ b/tur/python-fitsio/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/esheldon/fitsio
+TERMUX_PKG_DESCRIPTION="A python package for FITS input/output wrapping cfitsio"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="1.2.1"
+TERMUX_PKG_SRCURL=https://github.com/esheldon/fitsio/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=e55aeb6e9d3d76639798d7912c1ba1f7cc782c622feddb95c6b632a91f5fc3ad
+TERMUX_PKG_DEPENDS="cfitsio, python, python-numpy"
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, numpy"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	if $TERMUX_ON_DEVICE_BUILD; then
+		termux_error_exit "Package '$TERMUX_PKG_NAME' is not available for on-device builds."
+	fi
+	export FITSIO_USE_SYSTEM_FITSIO=1
+}


### PR DESCRIPTION
A dependency of astrometry.net, as mentioned in https://github.com/termux-user-repository/tur/issues/844. 

I can try building astrometry.net with `tur-on-device` only after this is pull request is accepted (`python-fitsio` cannot be built in `tur-on-device`, throwing [`x86_64-linux-android-clang: error: unknown argument: '-fno-openmp-implicit-rpath'`](https://github.com/knyipab/tur/actions/runs/8035672334/job/21948565280#step:7:5035)). 