### PR TITLE
astrometry.net and index files

### DIFF
--- a/tur/astrometry.net-data-basic/build.sh
+++ b/tur/astrometry.net-data-basic/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_HOMEPAGE=http://data.astrometry.net/
+TERMUX_PKG_DESCRIPTION="astrometry.net index data file 4115-4119, suitable for astro photos taken by phone main camera (AOV ~ 70 degrees)"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="copyright"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="1"
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+
+termux_step_post_get_source () {
+	cp "$TERMUX_PKG_BUILDER_DIR"/copyright "$TERMUX_PKG_SRCDIR"/
+}
+
+termux_step_make_install () {
+	mkdir -p "$TERMUX_PREFIX/data/"
+	termux_download http://data.astrometry.net/4100/index-4115.fits "$TERMUX_PREFIX/data/" 548f6c438b5062519e27e83bc7cdc1743705068e327fabe4cc039a4319542953
+	termux_download http://data.astrometry.net/4100/index-4116.fits "$TERMUX_PREFIX/data/" de811b8513cb2499ace8ce26a79ed8082e5ec19972f2a5d967e5c3b93c475b5a
+	termux_download http://data.astrometry.net/4100/index-4117.fits "$TERMUX_PREFIX/data/" 7de4d4f8827d5622ff1ed5252ab8b18d6b576b48f63a8927b5887bc8fa418f45
+	termux_download http://data.astrometry.net/4100/index-4118.fits "$TERMUX_PREFIX/data/" 5e79c1812ac6fdf11a360b04e82079b87e318ed36a618c21de23441195e67d0f
+	termux_download http://data.astrometry.net/4100/index-4119.fits "$TERMUX_PREFIX/data/" 79b36eea45b72448c8471f6e8af0e1c8635a3821d04f1a23d6cf5ecd5f59d31c
+}

--- a/tur/astrometry.net-data-basic/copyright
+++ b/tur/astrometry.net-data-basic/copyright
@@ -1,0 +1,7 @@
+The 4100-series index files are generated from and follow the license of the Tycho-2 catalogue. 
+
+The license information for the Tycho-2 catalogue: 
+Copyright 2000 Hog E., Fabricius C., Makarov V.V., Urban S., Corbin T., Wycoff G., Bastian U., Schwekendiek P., Wicenec A. 
+
+The Astrometry.net team claims copyright on the script to generate 4100-series index files (but not on the resulting index files):
+Copyright 2006-2015 Michael Blanton, David W. Hogg, Dustin Lang, Keir Mierle and Sam Roweis

--- a/tur/astrometry.net/0001-gsl-an-configure-cross-compile.patch
+++ b/tur/astrometry.net/0001-gsl-an-configure-cross-compile.patch
@@ -1,0 +1,13 @@
+diff --git a/gsl-an/Makefile b/gsl-an/Makefile
+index 8b9ced0..cf1995f 100644
+--- a/gsl-an/Makefile
++++ b/gsl-an/Makefile
+@@ -201,7 +201,7 @@ $(GSL_LIB): config.h $(GSL_OBJS)
+ 	$(RANLIB) $@
+ 
+ config.h: configure config.h.in
+-	./configure --enable-shared=no --prefix=`pwd`/stage
++	./configure --disable-rpath --disable-rpath-hack --enable-shared=no --host=x86_64-linux-android --prefix=`pwd`/stage 
+ 	touch $@
+ 
+ config.h.in: ;

--- a/tur/astrometry.net/0002-solver-landroid-glob.patch
+++ b/tur/astrometry.net/0002-solver-landroid-glob.patch
@@ -1,0 +1,13 @@
+diff --git a/solver/Makefile b/solver/Makefile
+index f225256..d5dfbcd 100644
+--- a/solver/Makefile
++++ b/solver/Makefile
+@@ -315,7 +315,7 @@ unpermute-stars: unpermute-stars-main.o $(SLIB)
+ ALL_OBJ += unpermute-stars-main.o
+ 
+ astrometry-engine: engine-main.o $(SLIB)
+-	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS)
++	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -landroid-glob
+ 
+ solve-field: solve-field.o augment-xylist.o image2xy-files.o $(SLIB) $(CFITS_SLIB)
+ 	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(CFITS_LIB) $(LDLIBS)

--- a/tur/astrometry.net/0003-ioutils-TMPDIR.patch
+++ b/tur/astrometry.net/0003-ioutils-TMPDIR.patch
@@ -1,0 +1,16 @@
+diff --git a/util/ioutils.c b/util/ioutils.c
+index 3a9bd48..91b8832 100644
+--- a/util/ioutils.c
++++ b/util/ioutils.c
+@@ -638,7 +638,11 @@ char* shell_escape(const char* str) {
+ }
+ 
+ static char* get_temp_dir() {
++#ifdef __TERMUX__
++    char* dir = getenv("TMPDIR");
++#else
+     char* dir = getenv("TMP");
++#endif
+     if (!dir) {
+         dir = "/tmp";
+     }

--- a/tur/astrometry.net/0004-bypass-netpbm-test.patch
+++ b/tur/astrometry.net/0004-bypass-netpbm-test.patch
@@ -1,0 +1,31 @@
+diff --git a/util/Makefile b/util/Makefile
+index c35a8da..0338b8f 100644
+--- a/util/Makefile
++++ b/util/Makefile
+@@ -267,11 +267,7 @@ $(INCLUDE_DIR)/os-features-config.h: os-features-test.c
+ 	@echo "   NETPBM_INC is $(NETPBM_INC_ORIG)"
+ 	@echo "   NETPBM_LIB is $(NETPBM_LIB_ORIG)"
+ 	@echo "Testing netpbm..." >> os-features.log
+-	(($(CC) -o os-features-test-netpbm \
+-	   $(CPPFLAGS) $(CFLAGS) $(NETPBM_INC_ORIG) $^ $(LDFLAGS) $(NETPBM_LIB_ORIG) >> os-features.log && \
+-	   ./os-features-test-netpbm >> os-features.log && \
+-	   echo "#define HAVE_NETPBM 1") \
+-	|| echo "#define HAVE_NETPBM 0") >> $@.tmp
++	echo "#define HAVE_NETPBM 1" >> $@.tmp
+ 	@echo "--------------- End of expected error messages -----------------"
+ 	@echo
+ 	mv $@.tmp $@
+@@ -297,12 +293,4 @@ makefile.os-features: os-features-test.c
+-	 (($(CC) -o os-features-test-netpbm-make \
+-	   $(CPPFLAGS) $(CFLAGS) $(NETPBM_INC_ORIG) $^ $(LDFLAGS) $(NETPBM_LIB_ORIG) >> os-features-makefile.log && \
+-	   ./os-features-test-netpbm-make >> os-features-makefile.log && \
+-	   echo "HAVE_NETPBM := yes") \
+-	|| (echo "# Astrometry.net didn't find netpbm; not setting HAVE_NETPBM."; \
+-		echo "# See os-features-makefile.log for details."; \
+-		echo "# To re-run this test, do 'make reconfig; make makefile.os-features' (in the 'util' directory)"; \
+-		echo "# Or to do it yourself, just uncomment this line:"; \
+-		echo "# HAVE_NETPBM := yes")) \
++	   echo "HAVE_NETPBM := yes"  \
+ 	; \
+ 	echo) > $@.tmp
+ 	@echo "--------------- End of expected error messages -----------------"

--- a/tur/astrometry.net/build.sh
+++ b/tur/astrometry.net/build.sh
@@ -1,0 +1,24 @@
+TERMUX_PKG_HOMEPAGE=https://astrometry.net/
+TERMUX_PKG_DESCRIPTION="automatic recognition of astronomical images"
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="0.94"
+TERMUX_PKG_SRCURL=https://github.com/dstndstn/astrometry.net/releases/download/${TERMUX_PKG_VERSION}/astrometry.net-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=38c0d04171ecae42033ce5c9cd0757d8c5fc1418f2004d85e858f29aee383c5f
+TERMUX_PKG_DEPENDS="cfitsio, curl, file, libandroid-glob, libbz2, libcairo, libjpeg-turbo, libpng, netpbm, python, python-numpy, python-fitsio, swig, wcslib, zlib"
+TERMUX_PKG_SUGGESTS="astrometry.net-data-basic"
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, setuptools, numpy"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BLACKLISTED_ARCHES="arm" # FIXME: arm cross-compile C compiler fails for unknown reason
+
+termux_step_make () {
+	make TERMUX_HOST_PLATFORM="$TERMUX_HOST_PLATFORM"
+	make py CAIRO_INC=-I"$TERMUX_PREFIX"/include/cairo
+	make extra CAIRO_INC=-I"$TERMUX_PREFIX"/include/cairo
+}
+
+termux_step_make_install () {
+	make install INSTALL_DIR="$TERMUX_PREFIX" CAIRO_INC=-I"$TERMUX_PREFIX"/include/cairo
+}


### PR DESCRIPTION
Few caveats:
* arm cannot cross compile for unknown reason and fails the configure test on CC ([this action log just FYI](https://github.com/knyipab/tur/actions/runs/8042104268)). I gave up fixing it and blacklisted this arch. 
* The most controversial patch is perhaps `tur/astrometry.net/0004-bypass-netpbm-test.patch`, needed becuz it does not run cross-compiled executable. With `netpbm` package installed and it does compile and links the libs, we can simply assume it to work. (Without netpbm on, `plot-constellations` in the test below will fail)


Tested working on my aarch64 device with a [Google Pixel Astrophoto from Google Blog](https://blog.research.google/2019/11/astrophotography-with-night-sight-on.html)
```
wget https://1.bp.blogspot.com/-RET3jzHjUdI/Xd2Z3zO_bVI/AAAAAAAAE-g/m9gTuElmcasdxzCVfI7QrKs6wmFpwW6zQCLcBGAsYHQ/s1600/image10.jpg
image_file=image10.jpg
solve-field -D output --no-plots -m "$PREFIX/tmp" --objs 1000 "$image_file"
jpegtopnm ${image_file} | plot-constellations -w output/${image_file%%.jpg}.wcs -o output-constellations.png -i - -B -b 5 -G 600 -g 0.8,0.8,0.8
plotann.py output/${image_file%%.jpg}.wcs ${image_file} output-ann.png --grid-size=5 --grid-label=15 --grid-color=0.8:0.8:0.8 --lw=10
```