### PR TITLE
addpkg(main/yc): Yao scripting language and Rig build system

### DIFF
--- a/tur/yc/build.sh
+++ b/tur/yc/build.sh
@@ -1,0 +1,44 @@
+TERMUX_PKG_HOMEPAGE=https://git.yzena.com/Yzena/Yc
+TERMUX_PKG_DESCRIPTION="Monopackage with Rig, Yao, and Yvm"
+TERMUX_PKG_LICENSE="custom" # Yc is under two licenses; both must be followed.
+TERMUX_PKG_LICENSE_FILE="LICENSE.YNL.md, LICENSE.SSPL.txt"
+TERMUX_PKG_MAINTAINER="Gavin D. Howard <gavin@yzena.com>"
+TERMUX_PKG_VERSION=24.04.04
+TERMUX_PKG_SRCURL=https://git.yzena.com/Yzena/Yc/releases/download/${TERMUX_PKG_VERSION}/${TERMUX_PKG_NAME}-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=5e0ca7e087048da37192c51ea9e6873b69c68dbd2668ac7682250e8498315fed
+TERMUX_PKG_HOSTBUILD=true
+
+# Yc has its own build system, so it needs to bootstrap on the host first.
+termux_step_host_build() {
+
+	cd "$TERMUX_PKG_BUILDDIR"
+
+	# The source needs to be in the build directory for bootstrap.
+	cp -r "$TERMUX_PKG_SRCDIR" ./bootstrap
+	cd ./bootstrap
+
+	# Yc has a C program that does the bootstrap.
+	gcc -o bootstrap/bootstrap bootstrap/bootstrap.c
+	./bootstrap/bootstrap gcc
+}
+
+termux_step_configure() {
+	cd "$TERMUX_PKG_BUILDDIR"
+	# It's just easier to have the source in the build directory for the build.
+	cp -r "$TERMUX_PKG_SRCDIR" ./yc
+}
+
+termux_step_make() {
+	cd "$TERMUX_PKG_BUILDDIR/yc"
+	# Yc's build likes to stomp on $PATH, so we need to stop that. It also needs
+	# to know that it is being built for Android, as well as what compiler to
+	# use. Finally, the build automatically defines _BSD_SOURCE, which doesn't
+	# work on Android.
+	../bootstrap/release/yc rigr --preserve-path --os=Android --compiler=clang \
+		--compiler-flag=-U_BSD_SOURCE
+}
+
+termux_step_make_install() {
+	cd "$TERMUX_PKG_BUILDDIR/yc"
+	install -Dm700 -T release/yc $TERMUX_PREFIX/bin/yc
+}

--- a/tur/yc/rigbuild.subpackage.sh
+++ b/tur/yc/rigbuild.subpackage.sh
@@ -1,0 +1,18 @@
+TERMUX_SUBPKG_DESCRIPTION="The Rig build system"
+TERMUX_SUBPKG_INCLUDE=""
+
+termux_step_create_subpkg_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	ln -sf ./yc $TERMUX_PREFIX/bin/rig
+	ln -sf ./yc $TERMUX_PREFIX/bin/rigr
+	ln -sf ./yc $TERMUX_PREFIX/bin/rigc
+	chmod 700 $TERMUX_PREFIX/bin/rig{r,c,}
+	exit 0
+	EOF
+	cat <<- EOF > ./prerm
+	#!$TERMUX_PREFIX/bin/sh
+	rm -f $TERMUX_PREFIX/bin/rig{r,c,}
+	exit 0
+	EOF
+}

--- a/tur/yc/yao.subpackage.sh
+++ b/tur/yc/yao.subpackage.sh
@@ -1,0 +1,16 @@
+TERMUX_SUBPKG_DESCRIPTION="The Yao programming language"
+TERMUX_SUBPKG_INCLUDE="bin/yc"
+
+termux_step_create_subpkg_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX/bin/sh
+	ln -sf ./yc $TERMUX_PREFIX/bin/yao
+	chmod 700 $TERMUX_PREFIX/bin/yao
+	exit 0
+	EOF
+	cat <<- EOF > ./prerm
+	#!$TERMUX_PREFIX/bin/sh
+	rm -f $TERMUX_PREFIX/bin/yao
+	exit 0
+	EOF
+}


### PR DESCRIPTION
More information about Yao and Rig is at https://rigbuild.dev/ .

Yao and Rig are part of a monorepo, so this package includes both.

Since Rig is a build system, it is its own build system, so this package requires a host build for bootstrap.

Both are currently in alpha, but a Termux user requested that I make this package.

That said, I understand if this package is not wanted, especially since this package is under the SSPL and another non-Open Source license, which may cause problems with parsing the license identifier.

If accepted, I intend to maintain this package.