### PR TITLE
new package: skyseg-ncnn

### DIFF
--- a/tur/skyseg-ncnn/build.sh
+++ b/tur/skyseg-ncnn/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/knyipab/skyseg-ncnn
+TERMUX_PKG_DESCRIPTION="Sky segmentation on image using ncnn machine learning model"
+TERMUX_PKG_DEPENDS="libncnn, opencv"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@knyipab"
+TERMUX_PKG_VERSION="0.1.0"
+TERMUX_PKG_SRCURL="https://github.com/knyipab/skyseg-ncnn/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=c8c5d6afa02cfce886c10ee331ec2382214881febdd124a4fc151a94fe0c80ca
+TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
A cmake build of xiongzhu666/Sky-Segmentation-and-Post-processing. Because in the original repository, the binary source code has no build script, no release and neither that relative path works well for Termux, I created a repository dedicated for it. This package is actually one of the building block of a tool I plan to package on TUR. 

Test script (for record)
```bash
curl -o demo.jpg -L https://lh3.googleusercontent.com/pw/AP1GczNsgYY61QHlnYai--x-scRy_QJbkqGyASQN39lcL5ZD_AcMitUQqQ8mWy8Bf_FruvknK0_Pw77VqO84FtGU4z8OZMWP2qWAkRnqHUrZYESZiuFNKpCHEzXCpQ6fdeT1wbiJuCgtbcea_60ym7NAzwxN=w943-h1257-s-no-gm

skyseg-ncnn demo.jpg demo-sky.jpg
```
In the test, it works well even for night sky. 

![demo](https://github.com/termux-user-repository/tur/assets/46513942/3f602087-2e7e-4e43-b5eb-08b7a4c81cc9)

![demo-sky](https://github.com/termux-user-repository/tur/assets/46513942/f1853e9d-be17-4ae5-a367-74c3ac1a111e)
