### PR TITLE
new packages: rife-ncnn-vulkan{,-nihui,-tntwise}

### DIFF
--- a/tur/rife-ncnn-vulkan-nihui/build.sh
+++ b/tur/rife-ncnn-vulkan-nihui/build.sh
@@ -1,0 +1,43 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/nihui/rife-ncnn-vulkan
+TERMUX_PKG_DESCRIPTION="RIFE, Real-Time Intermediate Flow Estimation for Video Frame Interpolation implemented with ncnn library"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=20221029
+TERMUX_PKG_SRCURL=git+https://github.com/nihui/rife-ncnn-vulkan
+TERMUX_PKG_DEPENDS="libwebp, vulkan-loader"
+TERMUX_PKG_ANTI_BUILD_DEPENDS="vulkan-loader"
+TERMUX_PKG_BUILD_DEPENDS="vulkan-loader-generic"
+TERMUX_PKG_GIT_BRANCH=20221029
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DUSE_SYSTEM_WEBP=ON"
+TERMUX_PKG_CONFLICTS="rife-ncnn-vulkan-tntwise"
+
+termux_step_pre_configure () {
+	git submodule update --init --recursive "$TERMUX_PKG_SRCDIR"
+	mv "$TERMUX_PKG_SRCDIR/src/"* "$TERMUX_PKG_SRCDIR/"
+	LDFLAGS+=" -llog -landroid"
+}
+
+termux_step_make_install () {
+	mkdir -p "$TERMUX_PREFIX/opt/rife-ncnn-vulkan"
+	install -Dm700 rife-ncnn-vulkan "$TERMUX_PREFIX/opt/rife-ncnn-vulkan"
+	ln -s "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-ncnn-vulkan" "$TERMUX_PREFIX/bin/rife-ncnn-vulkan"
+	cp -r models/rife-v2.3 "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-v2.3" # default value of model arg
+	cp -r models/rife-v4.6 "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-v4.6" # nihui's repo latest model
+	max_ver=0.0
+	max_lite_ver=0.0
+	for rife_dir in models/rife-v*; do
+		ver=$(basename "$rife_dir")
+		ver=${ver##rife-v}
+		[ "${#ver}" -eq 1 ] && ver="$ver.0"
+		if [ "${ver: -5}" == "-lite" ] && ver="${ver::-5}"; then
+			[ "${ver::1}" -ge "${max_lite_ver::1}" ] && [ "${ver:2}" -ge "${max_lite_ver:2}" ] && max_lite_ver="$ver"
+		elif [ "${ver::1}" -ge "${max_ver::1}" ] && [ "${ver:2}" -ge "${max_ver:2}" ]; then
+			max_ver="$ver"
+		fi
+	done
+	[ "$max_lite_ver" != 0.0 ] && cp -r models/rife-v"${max_lite_ver%%.0}"-lite "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-lite-latest"
+	[ "$max_ver" != 0.0 ] && cp -r models/rife-v"${max_ver%%.0}" "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-latest"
+}

--- a/tur/rife-ncnn-vulkan-tntwise/build.sh
+++ b/tur/rife-ncnn-vulkan-tntwise/build.sh
@@ -1,0 +1,43 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/TNTwise/rife-ncnn-vulkan
+TERMUX_PKG_DESCRIPTION="TNTwise's fork of rife-ncnn-vulkan: RIFE, Real-Time Intermediate Flow Estimation for Video Frame Interpolation implemented with ncnn library"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=20240326
+TERMUX_PKG_SRCURL=git+https://github.com/TNTwise/rife-ncnn-vulkan
+TERMUX_PKG_DEPENDS="libwebp, vulkan-loader"
+TERMUX_PKG_ANTI_BUILD_DEPENDS="vulkan-loader"
+TERMUX_PKG_BUILD_DEPENDS="vulkan-loader-generic"
+TERMUX_PKG_GIT_BRANCH=20240326
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE="newest-tag"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DUSE_SYSTEM_WEBP=ON"
+TERMUX_PKG_CONFLICTS="rife-ncnn-vulkan-nihui"
+
+termux_step_pre_configure () {
+	git submodule update --init --recursive "$TERMUX_PKG_SRCDIR"
+	mv "$TERMUX_PKG_SRCDIR/src/"* "$TERMUX_PKG_SRCDIR/"
+	LDFLAGS+=" -llog -landroid"
+}
+
+termux_step_make_install () {
+	mkdir -p "$TERMUX_PREFIX/opt/rife-ncnn-vulkan"
+	install -Dm700 rife-ncnn-vulkan "$TERMUX_PREFIX/opt/rife-ncnn-vulkan"
+	ln -s "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-ncnn-vulkan" "$TERMUX_PREFIX/bin/rife-ncnn-vulkan"
+	cp -r models/rife-v2.3 "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-v2.3" # default value of model arg
+	cp -r models/rife-v4.6 "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-v4.6" # nihui's repo latest model
+	max_ver=0.0
+	max_lite_ver=0.0
+	for rife_dir in models/rife-v*; do
+		ver=$(basename "$rife_dir")
+		ver=${ver##rife-v}
+		[ "${#ver}" -eq 1 ] && ver="$ver.0"
+		if [ "${ver: -5}" == "-lite" ] && ver="${ver::-5}"; then
+			[ "${ver::1}" -ge "${max_lite_ver::1}" ] && [ "${ver:2}" -ge "${max_lite_ver:2}" ] && max_lite_ver="$ver"
+		elif [ "${ver::1}" -ge "${max_ver::1}" ] && [ "${ver:2}" -ge "${max_ver:2}" ]; then
+			max_ver="$ver"
+		fi
+	done
+	[ "$max_lite_ver" != 0.0 ] && cp -r models/rife-v"${max_lite_ver%%.0}"-lite "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-lite-latest"
+	[ "$max_ver" != 0.0 ] && cp -r models/rife-v"${max_ver%%.0}" "$TERMUX_PREFIX/opt/rife-ncnn-vulkan/rife-latest"
+}

--- a/tur/rife-ncnn-vulkan/build.sh
+++ b/tur/rife-ncnn-vulkan/build.sh
@@ -1,0 +1,11 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/nihui/rife-ncnn-vulkan
+TERMUX_PKG_DESCRIPTION="A metapackage that provides rife-ncnn-vulkan"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=0.1
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="rife-ncnn-vulkan-nihui | rife-ncnn-vulkan-tntwise"
+TERMUX_PKG_ANTI_BUILD_DEPENDS="rife-ncnn-vulkan-nihui, rife-ncnn-vulkan-tntwise"
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_METAPACKAGE=true


### PR DESCRIPTION
managed to build [rife-ncnn-vulkan](https://github.com/nihui/rife-ncnn-vulkan) and tested with: 
```bash
rife-ncnn-vulkan -0 0.png -1 1.png -o test.png -m rife-v4.6 -g -1
```

It works **BUT** it cannot work using gpu (i.e. without `-g -1`), with error below: 
```
SPIR-V WARNING:
    In file ../src/compiler/spirv/spirv_to_nir.c:4862
    Unsupported SPIR-V capability: SpvCapabilityStorageBuffer8BitAccess (4448)
    36 bytes into the SPIR-V binary
validation fail: (type_size(instr->cat6.type) <= 16) == !!((instr->srcs[2])->flags & IR3_REG_HALF)
  -> for instruction: MESA: info: 0000:000: 	stib.base0 ssa_43, ssa_75, hssa_76
```
I have no ideas, but I speculate that even after solving this error, vulkan will likely generates black image (an issue I raised at https://github.com/nihui/rife-ncnn-vulkan/issues/41). 

Anyways, even with this caveat, I still want it to be listed on TUR. Thanks. 