### PR TITLE
ettercap: move from termux-packages/root-packages

### DIFF
--- a/tur-hacking/ettercap/CMakeLists.txt.patch
+++ b/tur-hacking/ettercap/CMakeLists.txt.patch
@@ -1,0 +1,11 @@
+--- ../CMakeLists.txt.orig	2019-08-27 20:30:33.670343601 +0200
++++ ./CMakeLists.txt	2019-08-27 20:29:32.497096038 +0200
+@@ -107,7 +107,7 @@
+ include(EttercapVariableCheck)
+ 
+ set(INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE PATH "Installation prefix")
+-set(INSTALL_SYSCONFDIR /etc CACHE PATH "System configuration directory")
++set(INSTALL_SYSCONFDIR @TERMUX_PREFIX@/etc CACHE PATH "System configuration directory")
+ set(INSTALL_LIBDIR ${INSTALL_PREFIX}/lib${LIB_SUFFIX} CACHE PATH "Library installation directory")
+ set(INSTALL_DATADIR ${INSTALL_PREFIX}/share CACHE PATH "Data installation directory")
+ set(INSTALL_EXECPREFIX ${INSTALL_PREFIX} CACHE PATH "")

--- a/tur-hacking/ettercap/build.sh
+++ b/tur-hacking/ettercap/build.sh
@@ -1,0 +1,14 @@
+TERMUX_PKG_HOMEPAGE=https://www.ettercap-project.org
+TERMUX_PKG_DESCRIPTION="Comprehensive suite for MITM attacks, can sniff live connections, do content filtering on the fly and much more"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=0.8.3.1
+TERMUX_PKG_REVISION=9
+TERMUX_PKG_SRCURL=https://github.com/Ettercap/ettercap/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=d0c3ef88dfc284b61d3d5b64d946c1160fd04276b448519c1ae4438a9cdffaf3
+TERMUX_PKG_DEPENDS="ethtool, libcurl, libiconv, libnet, libpcap, ncurses, ncurses-ui-libs, openssl, pcre, zlib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_BUILD_TYPE=Release
+-DENABLE_GTK=off
+-DENABLE_GEOIP=off
+"

--- a/tur-hacking/ettercap/cmake-Modules-EttercapLibCheck.cmake.patch
+++ b/tur-hacking/ettercap/cmake-Modules-EttercapLibCheck.cmake.patch
@@ -1,0 +1,15 @@
+--- ../EttercapLibCheck.cmake.orig	2019-08-27 19:47:07.065638380 +0200
++++ ./cmake/Modules/EttercapLibCheck.cmake	2019-08-27 19:48:04.867210840 +0200
+@@ -261,10 +261,8 @@
+     set(EC_LIBS ${EC_LIBS} ${HAVE_RESOLV})
+     set(HAVE_DN_EXPAND 1 CACHE PATH "Found dn_expand")
+ else()
+-    if(OS_BSD)
+-        # FreeBSD has dn_expand built in libc
+-        check_function_exists(dn_expand HAVE_DN_EXPAND)
+-    endif()
++    # FreeBSD and Android has dn_expand built in libc
++    check_function_exists(dn_expand HAVE_DN_EXPAND)
+ endif()
+ 
+ find_package(PCRE)

--- a/tur-hacking/ettercap/cmake-Modules-EttercapOSTest.cmake.patch
+++ b/tur-hacking/ettercap/cmake-Modules-EttercapOSTest.cmake.patch
@@ -1,0 +1,10 @@
+--- ../EttercapOSTest.cmake.orig	2019-08-27 19:01:04.600920329 +0200
++++ ./cmake/Modules/EttercapOSTest.cmake	2019-08-27 19:57:48.826678789 +0200
+@@ -1,5 +1,7 @@
+ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+     set(OS_LINUX 1)
++elseif(${CMAKE_SYSTEM_NAME} MATCHES "Android")
++    set(OS_LINUX 1)
+ elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+     set(OS_BSD 1)
+     set(OS_BSD_FREE 1)

--- a/tur-hacking/ettercap/ettercap-0.8.3.1-libcurl-8.patch
+++ b/tur-hacking/ettercap/ettercap-0.8.3.1-libcurl-8.patch
@@ -1,0 +1,36 @@
+https://github.com/Ettercap/ettercap/commit/40534662043b7d831d1f6c70448afa9d374a9b63
+
+From 40534662043b7d831d1f6c70448afa9d374a9b63 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 23 Mar 2023 10:23:14 -0700
+Subject: [PATCH] sslstrip: Enhance the libcurl version check to consider
+ version 8+
+
+Lately curl has released version 8 and hence LIBCURL_VERSION_MAJOR is
+reset to 0, current check assumes major version to be 7 at max and hence
+on systems with libcurl 8+ this check breaks and build fails
+
+Fixes
+
+TOPDIR/build/tmp/work/cortexa15t2hf-neon-yoe-linux-gnueabi/ettercap/0.8.3.1-r0/git/plug-ins/sslstrip/sslstrip.c:57:2: error: libcurl 7.26.0 or up is needed
+ ^
+1 error generated.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ plug-ins/sslstrip/sslstrip.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plug-ins/sslstrip/sslstrip.c b/plug-ins/sslstrip/sslstrip.c
+index 327bf58af..d9b67c8b6 100644
+--- a/plug-ins/sslstrip/sslstrip.c
++++ b/plug-ins/sslstrip/sslstrip.c
+@@ -51,7 +51,7 @@
+ 
+ #include <curl/curl.h>
+ 
+-#if (LIBCURL_VERSION_MAJOR < 7) || (LIBCURL_VERSION_MINOR < 26)
++#if (LIBCURL_VERSION_MAJOR < 7) || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR < 26)
+ #error libcurl 7.26.0 or up is needed
+ #endif
+ 

--- a/tur-hacking/ettercap/include-ec_threads.h.patch
+++ b/tur-hacking/ettercap/include-ec_threads.h.patch
@@ -1,0 +1,11 @@
+--- ../ec_threads.h.orig	2019-08-27 20:14:48.025423828 +0200
++++ ./include/ec_threads.h	2019-08-27 20:18:58.102432737 +0200
+@@ -33,7 +33,7 @@
+ 
+ #define RETURN_IF_NOT_MAIN() do{ if (strcmp(ec_thread_getname(EC_PTHREAD_SELF), EC_GBL_PROGRAM)) return; }while(0)
+ 
+-#define CANCELLATION_POINT()  pthread_testcancel()
++#define CANCELLATION_POINT()
+ 
+ #if defined(OS_DARWIN) || defined(OS_WINDOWS) || defined(OS_CYGWIN)
+    /* XXX - darwin and windows are broken, pthread_join hangs up forever */

--- a/tur-hacking/ettercap/src-ec_threads.c.patch
+++ b/tur-hacking/ettercap/src-ec_threads.c.patch
@@ -1,0 +1,58 @@
+--- a/src/ec_threads.c
++++ b/src/ec_threads.c
+@@ -233,6 +233,13 @@ pthread_t ec_thread_new_detached(char *n
+    return id;
+ }
+ 
++#ifdef __ANDROID__
++static void thread_signal_handler(int signum)
++{
++   pthread_exit(0);
++}
++#endif
++
+ /* 
+  * set the state of a thread 
+  * all the new thread MUST call this on startup
+@@ -250,8 +257,17 @@ void ec_thread_init(void)
+     * allow a thread to be cancelled as soon as the
+     * cancellation  request  is received
+     */
++#ifndef __ANDROID__
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
++#else
++   struct sigaction actions;
++   memset(&actions, 0, sizeof(actions));
++   sigemptyset(&actions.sa_mask);
++   actions.sa_flags = 0;
++   actions.sa_handler = thread_signal_handler;
++   sigaction(SIGUSR2, &actions, NULL);
++#endif
+ 
+    /* sync with the creator */ 
+    if ((e = pthread_cond_signal(&init_cond)))
+@@ -275,7 +291,11 @@ void ec_thread_destroy(pthread_t id)
+ 
+ 
+    /* send the cancel signal to the thread */
++#ifndef __ANDROID__
+    pthread_cancel((pthread_t)id);
++#else
++   pthread_kill((pthread_t)id, SIGUSR2);
++#endif
+ 
+ 
+    DEBUG_MSG("ec_thread_destroy -- [%s] terminated", ec_thread_getname(id));
+@@ -331,7 +351,11 @@ void ec_thread_kill_all(void)
+          DEBUG_MSG("ec_thread_kill_all -- terminating %lu [%s]", PTHREAD_ID(current->t.id), current->t.name);
+ 
+          /* send the cancel signal to the thread */
++#ifndef __ANDROID__
+          pthread_cancel((pthread_t)current->t.id);
++#else
++         pthread_kill((pthread_t)current->t.id, SIGUSR2);
++#endif
+          
+ #ifndef BROKEN_PTHREAD_JOIN
+          if (!current->t.detached) {

--- a/tur-hacking/ettercap/src-ec_ui.c.patch
+++ b/tur-hacking/ettercap/src-ec_ui.c.patch
@@ -1,0 +1,29 @@
+--- a/src/ec_ui.c
++++ b/src/ec_ui.c
+@@ -262,7 +262,14 @@ int ui_msg_flush(int max)
+ 	return 0; 
+ 
+    // don't allow the thread to cancel while holding the ui mutex
++#ifndef __ANDROID__
+    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old);
++#else
++   sigset_t pthread_cancel_block;
++   sigemptyset(&pthread_cancel_block);
++   sigaddset(&pthread_cancel_block, SIGUSR2);
++   sigprocmask(SIG_BLOCK, &pthread_cancel_block, NULL);
++#endif
+ 
+    /* the queue is updated by other threads */
+    UI_MSG_LOCK;
+@@ -285,7 +292,11 @@ int ui_msg_flush(int max)
+    
+    UI_MSG_UNLOCK;
+ 
++#ifndef __ANDROID__
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old);
++#else
++   sigprocmask(SIG_UNBLOCK, &pthread_cancel_block, NULL);
++#endif
+ 
+    /* returns the number of displayed messages */
+    return i;


### PR DESCRIPTION
Ettercap could be considered a dual-use package and could perhaps be put in tur-hacking instead. Plese let me know if that is preferable. 