### PR TITLE
new package: spleeter-proot

### DIFF
--- a/tur-on-device/spleeter-proot/LICENSE
+++ b/tur-on-device/spleeter-proot/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-present, Deezer SA.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tur-on-device/spleeter-proot/build.sh
+++ b/tur-on-device/spleeter-proot/build.sh
@@ -1,0 +1,42 @@
+TERMUX_PKG_HOMEPAGE=https://research.deezer.com/projects/spleeter.html
+TERMUX_PKG_DESCRIPTION="Audio source separation based, pacakged in proot"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=2.4.0
+TERMUX_PKG_SKIP_SRC_EXTRACT=true
+TERMUX_PKG_DEPENDS="proot-distro"
+TERMUX_PKG_BUILD_DEPENDS="wget"
+TERMUX_PKG_UNDEF_SYMBOLS_FILES=all
+
+TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686"
+
+termux_step_pre_configure() {
+	if [ "${TERMUX_ON_DEVICE_BUILD}" = false ]; then
+		termux_error_exit "This package doesn't support cross-compiling."
+	fi
+}
+
+termux_step_post_get_source () {
+	cp "$TERMUX_PKG_BUILDER_DIR"/LICENSE "$TERMUX_PKG_SRCDIR"/
+}
+
+termux_step_make_install(){
+	proot-distro install --override-alias app_spleeter ubuntu
+	proot-distro login app_spleeter --isolated -- eval useradd -U -m -s /bin/bash -p root android
+	proot-distro login app_spleeter --user android -- eval "
+mkdir -p ~/miniconda3
+wget https://repo.anaconda.com/miniconda/Miniconda3-py310_24.4.0-0-Linux-$TERMUX_ARCH.sh -O ~/miniconda3/miniconda.sh
+"
+	proot-distro login app_spleeter --user android --isolated -- eval "
+bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+rm -rf ~/miniconda3/miniconda.sh
+
+~/miniconda3/bin/conda config --set auto_activate_base false
+~/miniconda3/bin/conda create -n spleeter_py310 -y python=3.10
+~/miniconda3/bin/conda run -n spleeter_py310 pip install --no-deps spleeter
+~/miniconda3/bin/conda run -n spleeter_py310 pip install ffmpeg-python httpx==0.19.0 norbert typer==0.3.2
+~/miniconda3/bin/conda run -n spleeter_py310 pip install pandas==1.5.3 tensorflow==2.10
+"
+	install -Dm700 "$TERMUX_PKG_BUILDER_DIR"/spleeter-proot $TERMUX_PREFIX/bin/
+	ln -sfr $TERMUX_PREFIX/bin/spleeter-proot $TERMUX_PREFIX/bin/spleeter
+}

--- a/tur-on-device/spleeter-proot/spleeter-is-proot.subpackage.sh
+++ b/tur-on-device/spleeter-proot/spleeter-is-proot.subpackage.sh
@@ -1,0 +1,4 @@
+TERMUX_SUBPKG_DESCRIPTION="Symlinks to bin/spleeter"
+TERMUX_SUBPKG_INCLUDE="
+bin/spleeter
+"

--- a/tur-on-device/spleeter-proot/spleeter-proot
+++ b/tur-on-device/spleeter-proot/spleeter-proot
@@ -1,0 +1,3 @@
+#!/data/data/com.termux/files/usr/bin/sh
+
+proot-distro login --user android app_spleeter --shared-tmp --work-dir "$PWD" -- /home/android/miniconda3/bin/conda run -n spleeter_py310 spleeter "$@"


### PR DESCRIPTION
`spleeter` won't be available any time soon due to the lack of `tensorflow` (and `bazel`), so I want to package this `spleetee-proot` relying on `proot-distro`, perhaps resembling containerized app in Linux distro. 

May I know the answers of few questions: 
* Will TUR accept a proot app package like this?
* Does the build system offer "preinstall" script to check if `app_spleeter` prootf-distro rootfs exists during installation and if so then stop installation?
* Does the build system offer "uninstaller" script to run `proot-distro remove app_spleeter` to clean the rootfs thoroughly?