### PR TITLE
addpkg(zerotier-one): 1.14.0

### DIFF
--- a/tur/zerotier-one/0001-mask-setattr.patch
+++ b/tur/zerotier-one/0001-mask-setattr.patch
@@ -1,0 +1,16 @@
+# The only call to pthread_create() is in Thread.hpp, which has applied
+# a fix to the stack size general case. Disable the call to gnu extension
+# to make it compiles.
+diff --git a/one.cpp b/one.cpp
+index 2e4e638..9cd20ad 100644
+--- a/one.cpp
++++ b/one.cpp
+@@ -2088,7 +2088,7 @@ int __cdecl _tmain(int argc, _TCHAR* argv[])
+ int main(int argc,char **argv)
+ #endif
+ {
+-#if defined(__LINUX__) && ( (!defined(__GLIBC__)) || ((__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 18)) )
++#if !defined(__ANDROID__) && defined(__LINUX__) && ( (!defined(__GLIBC__)) || ((__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 18)) )
+ 	// This corrects for systems with abnormally small defaults (musl) and also
+ 	// shrinks the stack on systems with large defaults to save a bit of memory.
+ 	pthread_attr_t tattr;

--- a/tur/zerotier-one/0002-rust-target-os.patch
+++ b/tur/zerotier-one/0002-rust-target-os.patch
@@ -1,0 +1,108 @@
+--- a/rustybits/zeroidc/src/ext.rs	2024-07-04 12:58:54.585698700 +0800
++++ b/rustybits/zeroidc/src/ext.rs	2024-07-04 13:00:01.053008000 +0800
+@@ -22,6 +22,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn zeroidc_new(
+@@ -76,6 +77,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn zeroidc_delete(ptr: *mut ZeroIDC) {
+@@ -99,6 +101,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn zeroidc_start(ptr: *mut ZeroIDC) {
+@@ -115,6 +118,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn zeroidc_stop(ptr: *mut ZeroIDC) {
+@@ -131,6 +135,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn zeroidc_is_running(ptr: *mut ZeroIDC) -> bool {
+@@ -158,6 +163,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn zeroidc_set_nonce_and_csrf(ptr: *mut ZeroIDC, csrf_token: *const c_char, nonce: *const c_char) {
+@@ -188,6 +194,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn free_cstr(s: *mut c_char) {
+@@ -207,6 +214,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn zeroidc_get_auth_url(ptr: *mut ZeroIDC) -> *mut c_char {
+@@ -226,6 +234,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn zeroidc_token_exchange(idc: *mut ZeroIDC, code: *const c_char) -> *mut c_char {
+@@ -316,6 +325,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ #[no_mangle]
+ pub extern "C" fn zeroidc_kick_refresh_thread(idc: *mut ZeroIDC) {
+--- a/rustybits/zeroidc/src/lib.rs	2024-07-04 13:00:48.940037800 +0800
++++ b/rustybits/zeroidc/src/lib.rs	2024-07-04 13:00:51.757868600 +0800
+@@ -45,6 +45,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ pub struct ZeroIDC {
+     inner: Arc<Mutex<Inner>>,
+@@ -56,6 +57,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ struct Inner {
+     running: bool,
+@@ -110,6 +112,7 @@
+     all(target_os = "linux", target_arch = "aarch64"),
+     target_os = "windows",
+     target_os = "macos",
++    target_os = "android",
+ ))]
+ impl ZeroIDC {
+     pub fn new(

--- a/tur/zerotier-one/0003-osutils-termux-prefix.patch
+++ b/tur/zerotier-one/0003-osutils-termux-prefix.patch
@@ -1,0 +1,13 @@
+diff --git a/osdep/OSUtils.cpp b/osdep/OSUtils.cpp
+index 83c615d..7c04d48 100644
+--- a/osdep/OSUtils.cpp
++++ b/osdep/OSUtils.cpp
+@@ -444,7 +444,7 @@ std::string OSUtils::platformDefaultHomePath()
+ 	return std::string("/var/db/zerotier-one");
+ #else
+ 	// Use /var/lib for Linux and other *nix
+-	return std::string("/var/lib/zerotier-one");
++	return std::string("@TERMUX_PREFIX@/var/lib/zerotier-one");
+ #endif
+ 
+ #endif

--- a/tur/zerotier-one/0004-makefile-arm-workaround.patch
+++ b/tur/zerotier-one/0004-makefile-arm-workaround.patch
@@ -1,0 +1,32 @@
+diff --git a/make-linux.mk b/make-linux.mk
+index e232d93..ce8a934 100644
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -199,6 +199,11 @@ ifeq ($(CC_MACH),armv7)
+ 	override DEFS+=-DZT_NO_TYPE_PUNNING
+ 	ZT_USE_ARM32_NEON_ASM_CRYPTO=1
+ endif
++ifeq ($(CC_MACH),armv7a)
++	ZT_ARCHITECTURE=3
++	override DEFS+=-DZT_NO_TYPE_PUNNING
++	ZT_USE_ARM32_NEON_ASM_CRYPTO=1
++endif
+ ifeq ($(CC_MACH),armv7l)
+ 	ZT_ARCHITECTURE=3
+ 	override DEFS+=-DZT_NO_TYPE_PUNNING
+@@ -334,14 +338,10 @@
+ 
+ # ARM32 hell -- use conservative CFLAGS
+ ifeq ($(ZT_ARCHITECTURE),3)
+-	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
++	ifeq ($(shell if [ -e $(DESTDIR)/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
+ 		override CFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
+ 		override CXXFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
+ 		ZT_USE_ARM32_NEON_ASM_CRYPTO=0
+-	else
+-		override CFLAGS+=-mfloat-abi=hard -march=armv6zk -marm -mfpu=vfp -mno-unaligned-access -mtp=cp15 -mcpu=arm1176jzf-s
+-		override CXXFLAGS+=-mfloat-abi=hard -march=armv6zk -marm -mfpu=vfp -fexceptions -mno-unaligned-access -mtp=cp15 -mcpu=arm1176jzf-s
+-		ZT_USE_ARM32_NEON_ASM_CRYPTO=0
+ 	endif
+ endif
+ 

--- a/tur/zerotier-one/0004-makefile-arm-workaround.patch
+++ b/tur/zerotier-one/0004-makefile-arm-workaround.patch
@@ -9,24 +9,24 @@ index e232d93..ce8a934 100644
 +ifeq ($(CC_MACH),armv7a)
 +	ZT_ARCHITECTURE=3
 +	override DEFS+=-DZT_NO_TYPE_PUNNING
-+	ZT_USE_ARM32_NEON_ASM_CRYPTO=1
++	ZT_USE_ARM32_NEON_ASM_CRYPTO=0
 +endif
  ifeq ($(CC_MACH),armv7l)
  	ZT_ARCHITECTURE=3
  	override DEFS+=-DZT_NO_TYPE_PUNNING
-@@ -334,14 +338,10 @@
+@@ -347,6 +347,7 @@
  
  # ARM32 hell -- use conservative CFLAGS
  ifeq ($(ZT_ARCHITECTURE),3)
--	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
-+	ifeq ($(shell if [ -e $(DESTDIR)/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
++ifneq ($(CC_MACH),armv7a)
+ 	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
  		override CFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
  		override CXXFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
+@@ -357,6 +361,7 @@
  		ZT_USE_ARM32_NEON_ASM_CRYPTO=0
--	else
--		override CFLAGS+=-mfloat-abi=hard -march=armv6zk -marm -mfpu=vfp -mno-unaligned-access -mtp=cp15 -mcpu=arm1176jzf-s
--		override CXXFLAGS+=-mfloat-abi=hard -march=armv6zk -marm -mfpu=vfp -fexceptions -mno-unaligned-access -mtp=cp15 -mcpu=arm1176jzf-s
--		ZT_USE_ARM32_NEON_ASM_CRYPTO=0
  	endif
  endif
++endif
  
+ # Build faster crypto on some targets
+ ifeq ($(ZT_USE_X64_ASM_SALSA),1)

--- a/tur/zerotier-one/0005-makefile-cargo-target-name.patch
+++ b/tur/zerotier-one/0005-makefile-cargo-target-name.patch
@@ -1,0 +1,47 @@
+diff --git a/make-linux.mk b/make-linux.mk
+index 68138617..efde7a1d 100644
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -15,6 +15,9 @@ LDLIBS?=
+ DESTDIR?=
+ EXTRA_DEPS?=
+ 
++# FIXME: provide CARGO_TARGET_NAME or die
++CARGO_TARGET_NAME?=$(error set CARGO_TARGET_NAME in environment or make args)
++
+ include objects.mk
+ ONE_OBJS+=osdep/LinuxEthernetTap.o
+ ONE_OBJS+=osdep/LinuxNetLink.o
+@@ -75,6 +78,8 @@ else
+ 	ZT_CARGO_FLAGS=--release
+ endif
+ 
++ZT_CARGO_FLAGS+=--target $(CARGO_TARGET_NAME)
++
+ ifeq ($(ZT_QNAP), 1)
+ 	override DEFS+=-D__QNAP__
+ 	ZT_EMBEDDED=1
+@@ -301,9 +306,9 @@ ifeq ($(ZT_SSO_SUPPORTED), 1)
+ 	ifeq ($(ZT_EMBEDDED),)
+ 		override DEFS+=-DZT_SSO_SUPPORTED=1
+ 		ifeq ($(ZT_DEBUG),1)
+-			LDLIBS+=rustybits/target/debug/libzeroidc.a -ldl -lssl -lcrypto
++			LDLIBS+=rustybits/target/$(CARGO_TARGET_NAME)/debug/libzeroidc.a -ldl -lssl -lcrypto
+ 		else
+-			LDLIBS+=rustybits/target/release/libzeroidc.a -ldl -lssl -lcrypto
++			LDLIBS+=rustybits/target/$(CARGO_TARGET_NAME)/release/libzeroidc.a -ldl -lssl -lcrypto
+ 		endif
+ 	endif
+ endif
+@@ -331,9 +336,9 @@ ifeq ($(ZT_CONTROLLER),1)
+ 	override DEFS+=-DZT_CONTROLLER_USE_LIBPQ -DZT_NO_PEER_METRICS
+ 	override INCLUDES+=-I/usr/include/postgresql -Iext/libpqxx-7.7.3/install/ubuntu22.04/$(EXT_ARCH)/include -Iext/hiredis-1.0.2/include/ -Iext/redis-plus-plus-1.3.3/install/ubuntu22.04/$(EXT_ARCH)/include/sw/
+ 	ifeq ($(ZT_DEBUG),1)
+-		override LDLIBS+=rustybits/target/debug/libsmeeclient.a
++		override LDLIBS+=rustybits/target/$(CARGO_TARGET_NAME)/debug/libsmeeclient.a
+ 	else
+-		override LDLIBS+=rustybits/target/release/libsmeeclient.a
++		override LDLIBS+=rustybits/target/$(CARGO_TARGET_NAME)/release/libsmeeclient.a
+ 	endif
+ endif
+ 

--- a/tur/zerotier-one/0006-makefile-clang-simulate-as.patch
+++ b/tur/zerotier-one/0006-makefile-clang-simulate-as.patch
@@ -1,0 +1,14 @@
+
+diff --git a/make-linux.mk b/make-linux.mk
+index 77ef8e8c..263c74a6 100644
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -370,7 +370,7 @@ override CFLAGS+=-fPIC -fPIE
+ override CXXFLAGS+=-fPIC -fPIE
+ 
+ # Non-executable stack
+-override ASFLAGS+=--noexecstack
++ASFLAGS+=-c $(CFLAGS)
+ 
+ .PHONY: all
+ all:	one

--- a/tur/zerotier-one/0006-makefile-clang-simulate-as.patch
+++ b/tur/zerotier-one/0006-makefile-clang-simulate-as.patch
@@ -8,7 +8,7 @@ index 77ef8e8c..263c74a6 100644
  
  # Non-executable stack
 -override ASFLAGS+=--noexecstack
-+ASFLAGS+=-c $(CFLAGS)
++override ASFLAGS+=-c -Wa,--noexecstack
  
  .PHONY: all
  all:	one

--- a/tur/zerotier-one/0007-makefile-checkdep-destdir.patch
+++ b/tur/zerotier-one/0007-makefile-checkdep-destdir.patch
@@ -1,0 +1,31 @@
+diff --git a/make-linux.mk b/make-linux.mk
+index 263c74a6..9e7498e8 100644
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -12,7 +12,7 @@ endif
+ INCLUDES?=-Irustybits/target -isystem ext -Iext/prometheus-cpp-lite-1.0/core/include -Iext-prometheus-cpp-lite-1.0/3rdparty/http-client-lite/include -Iext/prometheus-cpp-lite-1.0/simpleapi/include
+ DEFS?=
+ LDLIBS?=
+-DESTDIR?=
++DESTDIR?=/usr
+ EXTRA_DEPS?=
+ 
+ # FIXME: provide CARGO_TARGET_NAME or die
+@@ -29,6 +29,8 @@ TIMESTAMP=$(shell date +"%Y%m%d%H%M")
+ # otherwise build into binary as done on Mac and Windows.
+ ONE_OBJS+=osdep/PortMapper.o
+ override DEFS+=-DZT_USE_MINIUPNPC
++# TODO: current upnpc is too new (UPNP_GetValidIGD changed in 2.2.8), so
++# keep it unchanged until upstream fix it
+ MINIUPNPC_IS_NEW_ENOUGH=$(shell grep -sqr '.*define.*MINIUPNPC_VERSION.*"2..*"' /usr/include/miniupnpc/miniupnpc.h && echo 1)
+ #MINIUPNPC_IS_NEW_ENOUGH=$(shell grep -sqr '.*define.*MINIUPNPC_VERSION.*"2.."' /usr/include/miniupnpc/miniupnpc.h && echo 1)
+ ifeq ($(MINIUPNPC_IS_NEW_ENOUGH),1)
+@@ -38,7 +40,7 @@ else
+ 	override DEFS+=-DMINIUPNP_STATICLIB -DMINIUPNPC_SET_SOCKET_TIMEOUT -DMINIUPNPC_GET_SRC_ADDR -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -DOS_STRING="\"Linux\"" -DMINIUPNPC_VERSION_STRING="\"2.0\"" -DUPNP_VERSION_STRING="\"UPnP/1.1\"" -DENABLE_STRNATPMPERR
+ 	ONE_OBJS+=ext/miniupnpc/connecthostport.o ext/miniupnpc/igd_desc_parse.o ext/miniupnpc/minisoap.o ext/miniupnpc/minissdpc.o ext/miniupnpc/miniupnpc.o ext/miniupnpc/miniwget.o ext/miniupnpc/minixml.o ext/miniupnpc/portlistingparse.o ext/miniupnpc/receivedata.o ext/miniupnpc/upnpcommands.o ext/miniupnpc/upnpdev.o ext/miniupnpc/upnperrors.o ext/miniupnpc/upnpreplyparse.o
+ endif
+-ifeq ($(wildcard /usr/include/natpmp.h),)
++ifeq ($(wildcard $(DESTDIR)/include/natpmp.h),)
+ 	ONE_OBJS+=ext/libnatpmp/natpmp.o ext/libnatpmp/getgateway.o
+ else
+ 	LDLIBS+=-lnatpmp

--- a/tur/zerotier-one/0008-makefile-install-add-selftest.patch
+++ b/tur/zerotier-one/0008-makefile-install-add-selftest.patch
@@ -1,0 +1,21 @@
+diff --git a/make-linux.mk b/make-linux.mk
+index 70a13911..c14e0114 100644
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -376,7 +376,7 @@ override ASFLAGS+=-Wa,-noexecstack
+ all:	one
+ 
+ .PHONY: one
+-one: zerotier-one zerotier-idtool zerotier-cli
++one: zerotier-one zerotier-idtool zerotier-cli zerotier-selftest
+ 
+ from_builder:	FORCE
+ 	ln -sf zerotier-one zerotier-idtool
+@@ -465,6 +465,7 @@ install:	FORCE
+ 	mkdir -p $(DESTDIR)/usr/sbin
+ 	rm -f $(DESTDIR)/usr/sbin/zerotier-one
+ 	cp -f zerotier-one $(DESTDIR)/usr/sbin/zerotier-one
++	cp -f zerotier-selftest $(DESTDIR)/usr/sbin/zerotier-selftest
+ 	rm -f $(DESTDIR)/usr/sbin/zerotier-cli
+ 	rm -f $(DESTDIR)/usr/sbin/zerotier-idtool
+ 	ln -s zerotier-one $(DESTDIR)/usr/sbin/zerotier-cli

--- a/tur/zerotier-one/build.sh
+++ b/tur/zerotier-one/build.sh
@@ -7,8 +7,6 @@ TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="1.14.0"
 TERMUX_PKG_SRCURL=https://github.com/zerotier/ZeroTierOne/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_DEPENDS="miniupnpc, natpmpc, openssl"
-# static is for arm, see step_conf
-TERMUX_PKG_BUILD_DEPENDS="natpmpc-static"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_SHA256=7191623a81b0d1b552b9431e8864dd3420783ee518394ac1376cee6aaf033291
@@ -18,12 +16,7 @@ TERMUX_PKG_SERVICE_SCRIPT=(
 
 termux_step_configure() {
 	termux_setup_rust
-	if [ "$TERMUX_ARCH" == "arm" ]; then
-		# the salsa2012 neon asm code cannot link by ld.lld with -pie
-		# ld.lld: error: relocation R_ARM_ABS32 cannot be used against local symbol; recompile with -fPIC
-		# https://stackoverflow.com/a/75048788: use static
-		TERMUX_PKG_EXTRA_MAKE_ARGS+="ZT_STATIC=1"
-	fi
+
 	sed \
 	-e 's/usr\///g' \
 	-e 's/sbin/bin/g' \

--- a/tur/zerotier-one/build.sh
+++ b/tur/zerotier-one/build.sh
@@ -1,0 +1,41 @@
+TERMUX_PKG_HOMEPAGE=https://www.zerotier.com
+TERMUX_PKG_DESCRIPTION="Creates virtual Ethernet networks of almost unlimited size."
+# LICENSE: Business Source License 1.1 (BSL-1.1)
+TERMUX_PKG_LICENSE="non-free"
+TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.14.0"
+TERMUX_PKG_SRCURL=https://github.com/zerotier/ZeroTierOne/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_DEPENDS="miniupnpc, natpmpc, openssl"
+# static is for arm, see step_conf
+TERMUX_PKG_BUILD_DEPENDS="natpmpc-static"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_SHA256=7191623a81b0d1b552b9431e8864dd3420783ee518394ac1376cee6aaf033291
+TERMUX_PKG_SERVICE_SCRIPT=(
+	'zerotier-one' 'exec su -c "'$TERMUX_PREFIX'/bin/zerotier-one -d"'
+)
+
+termux_step_configure() {
+	termux_setup_rust
+	if [ "$TERMUX_ARCH" == "arm" ]; then
+		# the salsa2012 neon asm code cannot link by ld.lld with -pie
+		# ld.lld: error: relocation R_ARM_ABS32 cannot be used against local symbol; recompile with -fPIC
+		# https://stackoverflow.com/a/75048788: use static
+		TERMUX_PKG_EXTRA_MAKE_ARGS+="ZT_STATIC=1"
+	fi
+	sed \
+	-e 's/usr\///g' \
+	-e 's/sbin/bin/g' \
+	-e 's/LDFLAGS=/LDFLAGS?=/' \
+	-e 's/RUSTFLAGS=/RUSTFLAGS?=/' \
+	-i make-linux.mk
+	make echo_flags
+}
+
+termux_step_make() {
+	export DESTDIR="${TERMUX_PREFIX}"
+	make selftest -j $TERMUX_PKG_MAKE_PROCESSES ${QUIET_BUILD=""} ${TERMUX_PKG_EXTRA_MAKE_ARGS=""}
+	# ./zerotier-selftest
+	make -j $TERMUX_PKG_MAKE_PROCESSES $QUIET_BUILD ${TERMUX_PKG_EXTRA_MAKE_ARGS}
+}


### PR DESCRIPTION
- port for rust build
- use static build on arm to satisfy lld linking with plain asm
- install zerotier-selftest
- adjust config location for termux

zerotier-one needs to create network interface, so NET_* capabilities should be given.
currently zerotier seemed to use route table related to `ip route`, which is not useful under android. To use it conveniently future works like scripts for convert `ip route` to `ip rule` are needed.

as for the `build.sh`, it's possible to specify (w/ build) dependencies to speed up building, as I only use static library for arm, and currenly miniupnpc is not used (the version zerotier depends is too old). So improvements are appreciated ;)