### PR TITLE
addpkg(tur/leanify): 0.4.3+20231217

### DIFF
--- a/tur/leanify/build.sh
+++ b/tur/leanify/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/JayXon/Leanify.git
+TERMUX_PKG_DESCRIPTION="Lightweight lossless file minifier/optimize"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION=0.4.3+20231217
+TERMUX_PKG_GIT_BRANCH=master
+TERMUX_PKG_SRCURL=git+https://github.com/JayXon/Leanify.git
+TERMUX_PKG_DEPENDS='libiconv'
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_post_configure() {
+	LDFLAGS+=' -liconv'
+	CFLAGS+=' -Wno-error=unused-but-set-variable'
+	case "$TERMUX_ARCH" in
+		'arm'|'i686') CFLAGS+=' -Wno-error=format';;
+	esac
+}
+
+# Makefile includes no install target
+termux_step_make_install() {
+	install -Dm755 -t "$TERMUX_PREFIX/bin" "${TERMUX_PKG_SRCDIR}/leanify"
+}


### PR DESCRIPTION
Requested in: 
- termux/termux-packages#20885

> [!NOTE]
> Checklist:
> - [x] Builds locally
> - [ ] Builds on CI
> - [x] Tested on device (Android 13, AArch64, Fairphone 5)

<h1><em></em></h1> <!-- thin separator -->

@TPS, if you wouldn't mind I'd appreciate if you could check the package for correct functioning.
I just did a basic "does it print its help and version information" test.
Instructions below.

<sup>(This is a pre-written, saved reply.)</sup>
If you want to test this PR please download the appropriate DEB package(s)
from the build artifacts of the [associated PR's latest CI run](https://github.com/termux-user-repository/tur/actions/runs/9987167934).
![Screenshot_20240619_232413](https://github.com/user-attachments/assets/6550dfa1-f1f2-4d86-ba62-cdbc6e9764c2)


After downloading the build artifact, make sure to `unzip` and un-`tar` it.
<details><summary>Detailed instructions, if needed.</summary>
<p>

```bash
# finding out what architecture you need
# architecture is just below the TERMUX_VERSION
termux-info

# e.g.
# [...]
# TERMUX_MAIN_PACKAGE_FORMAT=debian
# TERMUX_VERSION=0.118.0
# TERMUX__USER_ID=0
# Packages CPU architecture:
# aarch64
# [...]

# =======================

# make sure `unzip` and `tar` are installed using
pkg install unzip tar

# unzip the artifact (if you have a different architecture this might be arm, i686 or x86_64 instead)
unzip debs-aarch64-*.zip

# untar the artifact
tar xf debs-aarch64-*.tar

# You should now have a debs/ directory in your current working directory
# Install the packages from the local source using
pkg install -- ./debs/*.deb

# to clean up, you can remove the debs/ directory, .tar file and .zip file
rm -rfi debs debs-aarch64-*.zip debs-aarch64-*.tar
```

</p>
</details> 