### PR TITLE
github actions: allow runs on development branches

### DIFF
--- a/.github/workflows/package_continuous.yml
+++ b/.github/workflows/package_continuous.yml
@@ -20,6 +20,8 @@ on:
   push:
     branches:
     - master
+    - dev
+    - 'dev/**'
     paths:
     - 'tur-continuous/**'
   pull_request:
@@ -863,7 +865,7 @@ jobs:
 
   trigeer:
     runs-on: ubuntu-22.04
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.ref != 'refs/heads/dev' && !startsWith(github.ref, 'refs/heads/dev/')
     needs: finished-build
     steps:
     - name: Trigger workflow in dists repository

--- a/.github/workflows/package_on_device.yml
+++ b/.github/workflows/package_on_device.yml
@@ -21,6 +21,8 @@ on:
   push:
     branches:
     - master
+    - dev
+    - 'dev/**'
     paths:
     - 'tur-on-device/**'
   pull_request:
@@ -405,7 +407,7 @@ jobs:
         rm -rf ./artifacts ./debs
 
   upload:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.ref != 'refs/heads/dev' && !startsWith(github.ref, 'refs/heads/dev/')
     needs: [ build-x86, build-arm ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -20,6 +20,8 @@ on:
   push:
     branches:
     - master
+    - dev
+    - 'dev/**'
     paths:
     - 'tur/**'
     - 'tur-multilib/**'
@@ -231,7 +233,7 @@ jobs:
         path: ./artifacts
 
   upload:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.ref != 'refs/heads/dev' && !startsWith(github.ref, 'refs/heads/dev/')
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Basically adapted from https://github.com/termux/termux-packages/commit/0bff714afc6ce9351360984916146590d3376276
allow github build more conveniently thru pushing to `dev/*` or `dev` branch. 
may also revise readme.md accordingly. 