### PR TITLE
new package: tabby

### DIFF
--- a/tur/tabby/0001-llama-cpp-crosscompiling.patch
+++ b/tur/tabby/0001-llama-cpp-crosscompiling.patch
@@ -1,0 +1,19 @@
+diff --git a/crates/llama-cpp-server/build.rs b/crates/llama-cpp-server/build.rs
+index 35a4edb..3837363 100644
+--- a/crates/llama-cpp-server/build.rs
++++ b/crates/llama-cpp-server/build.rs
+@@ -12,6 +12,14 @@ fn main() {
+     config.profile("Release");
+     config.define("GGML_NATIVE", "OFF");
+     config.define("GGML_NATIVE_DEFAULT", "OFF");
++    config.define("GGML_BLAS", "ON");
++    config.define("GGML_BLAS_VENDOR", "OpenBLAS");
++    config.define("GGML_OPENMP", "ON");
++    config.define("GGML_AVX", "OFF");
++    config.define("GGML_AVX2", "OFF");
++    config.define("GGML_AVX512", "OFF");
++    config.define("GGML_FMA", "OFF");
++    config.define("GGML_F16C", "OFF");
+     config.define("BUILD_SHARED_LIBS", "OFF");
+ 
+     if cfg!(target_os = "macos") {

--- a/tur/tabby/build.sh
+++ b/tur/tabby/build.sh
@@ -1,0 +1,39 @@
+TERMUX_PKG_HOMEPAGE=https://tabby.tabbyml.com/
+TERMUX_PKG_DESCRIPTION="Self-hosted AI coding assistant"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=0.17.0
+TERMUX_PKG_SRCURL=git+https://github.com/TabbyML/tabby
+TERMUX_PKG_DEPENDS="graphviz, libopenblas, libsqlite"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
+# simd-json v0.13.10 fail to compile for i686 with error related to avx2 instructions
+# ARM_NEON is not supported by arm, therefore llama.cpp/ggml uses undeclared identifier 'vld1q_f16'
+TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686"
+
+termux_step_pre_configure() {
+	termux_setup_rust
+	termux_setup_cmake
+
+	# Dummy CMake toolchain file to workaround build error:
+	# CMake Error at /home/builder/.termux-build/_cache/cmake-3.30.3/share/cmake-3.30/Modules/Platform/Android-Determine.cmake:218 (message):
+	# Android: Neither the NDK or a standalone toolchain was found.
+	export TARGET_CMAKE_TOOLCHAIN_FILE="${TERMUX_PKG_BUILDDIR}/android.toolchain.cmake"
+	touch "${TERMUX_PKG_BUILDDIR}/android.toolchain.cmake"
+
+	if [ "$TERMUX_ARCH" = "x86_64" ]; then
+		RUSTFLAGS+=" -C link-arg=$($CC -print-libgcc-file-name)"
+	fi
+
+	LDFLAGS+=" -fopenmp -static-openmp"
+}
+
+termux_step_make() {
+	cargo build --jobs $TERMUX_PKG_MAKE_PROCESSES --target $CARGO_TARGET_NAME --release
+}
+
+termux_step_make_install() {
+	install -Dm700 target/${CARGO_TARGET_NAME}/release/tabby $TERMUX_PREFIX/bin/
+	install -Dm700 target/${CARGO_TARGET_NAME}/release/llama-server $TERMUX_PREFIX/bin/
+}


### PR DESCRIPTION
Open-source AI coding assistant, a promising alternative to copilot. 

Command to test:
```
tabby serve --model DeepseekCoder-1.3B --chat-model Qwen2-1.5B-Instruct
```
Then go to localhost:8080 to register an account. May also try the VS Code plugin so it work like copilot. 

Same as ollama, OpenBLAS (cpu) backend is used and no GPU / NPU backend is currently available. 