### PR TITLE
bump(tur/pacman-contrib): 1.10.6

### DIFF
--- a/tur/pacman-contrib/build.sh
+++ b/tur/pacman-contrib/build.sh
@@ -1,33 +1,32 @@
 TERMUX_PKG_HOMEPAGE=https://gitlab.archlinux.org/pacman/pacman-contrib
 TERMUX_PKG_DESCRIPTION="Additional libalpm utilities contributed by Arch community"
 TERMUX_PKG_LICENSE="GPL-3.0"
-TERMUX_PKG_MAINTAINER="@flosnvjx"
-TERMUX_PKG_VERSION=1.7.1
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=1.10.6
 TERMUX_PKG_SRCURL="https://gitlab.archlinux.org/pacman/pacman-contrib/-/archive/v$TERMUX_PKG_VERSION/pacman-contrib-v$TERMUX_PKG_VERSION.tar.gz"
-TERMUX_PKG_SHA256=81ad0af095fa2a686975bc11b4eb3b6602da60196e82819fb7a92f6fae5bf16d
+TERMUX_PKG_SHA256=fe8456638444ee6bead13ed526e047f8d251188582c085551afb29774ec468a8
 TERMUX_PKG_DEPENDS="pacman"
 TERMUX_PKG_BUILD_DEPENDS="asciidoc, perl, bsdtar"
 TERMUX_PKG_RECOMMENDS="diffutils, bsdtar"
 TERMUX_PKG_SUGGESTS="vim, mlocate, perl"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-git-version"
-#TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_METHOD=repology
+TERMUX_PKG_SERVICE_SCRIPT=(
+	'paccache' 'exec paccache -r 2>&1'
+	'pacman-filesdb-refresh' 'exec pacman -Fy 2>&1'
+)
+TERMUX_PKG_RM_AFTER_INSTALL="
+	lib
+	bin/checkupdates
+	bin/paclist
+	share/man/man8/checkupdates.8
+	share/man/man8/paclist.8
+	share/zsh/site-functions/_checkupdates
+	share/zsh/site-functions/_paclist
+"
 
 termux_step_pre_configure() {
-	cd $TERMUX_PKG_SRCDIR
-	export PKG_CONFIG_PATH="$TERMUX_PREFIX/share/pkgconfig"
 	./autogen.sh
-}
-
-termux_step_post_make_install() {
-	rm -rf $TERMUX_PREFIX/usr/lib/systemd
-
-	## pactree -s may require `pacman-key --init`
-	local disabledUtils=(checkupdates paclist)
-	local util=
-	for util in $disabledUtils;do
-		rm $TERMUX_PREFIX/bin/$util
-		rm $TERMUX_PREFIX/share/man/man8/$util.8* || :
-		rm $TERMUX_PREFIX/share/zsh/site-functions/_$util || :
-	done
 }


### PR DESCRIPTION
This came up in the Discord, specifically the systemd services not being removed.
So I decided to take a look at a build script and to be diplomatic this was just really damn sloppy.
I overhauled the build script and updated the package to the latest version.

<h1><em></em></h1> <!-- thin separator -->

I don't want to keep banging on about this, but I just want to quickly point out how many problems the old build script had.
- Systemd services were not being removed
- `paclist` was getting shipped despite supposedly being disabled
because accessing an array without an index only returns the first element.
https://github.com/termux-user-repository/tur/blob/d83bcc0b428088a99b4be6d0cc6b5c9c7a46f2cd/tur/pacman-contrib/build.sh#L26-L28
- That entire removal shenanigans should have been put into `termux_step_post_massage()`
Or better yet just use `TERMUX_PKG_RM_AFTER_INSTALL` which is the control variable specifically for removing files from a package.
- Auto updates were only half disable, I've turned them back on as a test.
- No `sv` services were being provided as equivalents to the Systemd services.
- `PKG_CONFIG_PATH` was being exported to its existing default value for no apparent reason