### PR TITLE
Add PyPI extra index URL to pip.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ TUR also hosts a PyPI index and contains some prebuilt Python packages.
 python -m pip install some_packages --extra-index-url https://termux-user-repository.github.io/pypi/
 ```
 
+You can add this index to your pip config for convenience by adding the following lines to your pip config (`~/.config/pip/pip.conf`):
+```
+[install]
+extra-index-url = https://termux-user-repository.github.io/pypi/
+```
+
 ## Request
 *Request to all TUR users.*
 


### PR DESCRIPTION
Add a note with instructions to add the extra index URL to pip.conf.

Not really relevant to this PR, but I personally also have the pip cache set as well, since I update infrequently (*months* in between) and have many packages and frequently forget to flush the cache; this allows Android to manage that.
```
[global]
cache-dir = /data/data/com.termux/cache/pip
```
