### PR TITLE
addpkg(tur/luanti): minetest for X11 on Android

### DIFF
--- a/tur/luanti/build.sh
+++ b/tur/luanti/build.sh
@@ -1,0 +1,32 @@
+TERMUX_PKG_HOMEPAGE=https://www.luanti.org
+TERMUX_PKG_DESCRIPTION="An open source voxel game engine."
+TERMUX_PKG_LICENSE="LGPL-2.1"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=2024.11.03
+_COMMIT=9982c563730f294d404119a2b8ffe26073134884
+TERMUX_PKG_SRCURL=git+https://github.com/minetest/minetest.git
+TERMUX_PKG_GIT_BRANCH=master
+TERMUX_PKG_SHA256=0aa7f0b08de6e7b74c522f62a354e88f8a291da53c4b0e38ca4f4cb10f6d2e86
+# incomplete depends, i dont have time yet to write the perfect depends for this
+TERMUX_PKG_DEPENDS="sdl2, libc++, openal-soft, libvorbis, libsqlite, freetype, libpng, libcurl, libandroid-spawn"
+
+termux_step_pre_configure() {
+	export LDFLAGS+=" -landroid-spawn"
+}
+
+termux_step_post_get_source() {
+	git fetch --unshallow
+	git checkout $_COMMIT
+
+	local version="$(git log -1 --format=%cs | sed 's/-/./g')"
+	if [ "$version" != "$TERMUX_PKG_VERSION" ]; then
+		echo -n "ERROR: The specified version \"$TERMUX_PKG_VERSION\""
+		echo " is different from what is expected to be: \"$version\""
+		return 1
+	fi
+
+	local s=$(find . -type f ! -path '*/.git/*' -print0 | xargs -0 sha256sum | LC_ALL=C sort | sha256sum)
+	if [[ "${s}" != "${TERMUX_PKG_SHA256}  "* ]]; then
+		termux_error_exit "Checksum mismatch for source files."
+	fi
+}

--- a/tur/luanti/minetest-bionic-libc-x11-wsi-opengl-es-2.patch
+++ b/tur/luanti/minetest-bionic-libc-x11-wsi-opengl-es-2.patch
@@ -1,0 +1,771 @@
+I created this patch quickly and I might not have time to update it often,
+but if you have questions about how this works, you can ask robertkirkman on
+github or owokitty on discord. 
+
+The basic idea is, this is Android but I disable everything I know is designed
+for SurfaceFlinger display server and replace it with everything that I know
+is for the X11 display server, while keeping everything else the same.
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 282fea4df..cc75e2286 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -89,13 +89,6 @@ set(ENABLE_UPDATE_CHECKER (NOT ${DEVELOPMENT_BUILD}) CACHE BOOL
+ # Included stuff
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+ 
+-# Load default options for Android
+-if(ANDROID)
+-	cmake_minimum_required(VERSION 3.20)
+-	include(AndroidLibs)
+-endif()
+-
+-
+ if(TRUE)
+ 	message(STATUS "Using imported IrrlichtMt at subdirectory 'irr'")
+ 	if(BUILD_CLIENT)
+diff --git a/irr/src/CIrrDeviceSDL.cpp b/irr/src/CIrrDeviceSDL.cpp
+index 60cf54d04..c4f47ac3c 100644
+--- a/irr/src/CIrrDeviceSDL.cpp
++++ b/irr/src/CIrrDeviceSDL.cpp
+@@ -305,7 +305,7 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
+ #endif
+ 
+ 	if (++SDLDeviceInstances == 1) {
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 		// Blocking on pause causes problems with multiplayer.
+ 		// See https://github.com/minetest/minetest/issues/10842.
+ 		SDL_SetHint(SDL_HINT_ANDROID_BLOCK_ON_PAUSE, "0");
+@@ -794,7 +794,7 @@ bool CIrrDeviceSDL::run()
+ #endif
+ 
+ 			auto button = SDL_event.button.button;
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 			// Android likes to send the right mouse button as the back button.
+ 			// According to some web searches I did, this is probably
+ 			// vendor/device-specific.
+diff --git a/irr/src/CIrrDeviceSDL.h b/irr/src/CIrrDeviceSDL.h
+index b52422423..cecc56923 100644
+--- a/irr/src/CIrrDeviceSDL.h
++++ b/irr/src/CIrrDeviceSDL.h
+@@ -161,7 +161,7 @@ class CIrrDeviceSDL : public CIrrDeviceStub
+ 		//! Sets the new position of the cursor.
+ 		void setPosition(s32 x, s32 y) override
+ 		{
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 			// On Android, this somehow results in a camera jump when enabling
+ 			// relative mouse mode and it isn't supported anyway.
+ 			SDL_WarpMouseInWindow(Device->Window,
+diff --git a/irr/src/CMakeLists.txt b/irr/src/CMakeLists.txt
+index 41d6645e9..53fd8c67d 100644
+--- a/irr/src/CMakeLists.txt
++++ b/irr/src/CMakeLists.txt
+@@ -61,11 +61,6 @@ if(WIN32)
+ elseif(APPLE)
+ 	add_definitions(-D_IRR_OSX_PLATFORM_)
+ 	set(DEVICE "OSX")
+-elseif(ANDROID)
+-	add_definitions(-D_IRR_ANDROID_PLATFORM_)
+-	if(NOT USE_SDL2)
+-		message(FATAL_ERROR "The Android build requires SDL2")
+-	endif()
+ elseif(EMSCRIPTEN)
+ 	add_definitions(-D_IRR_EMSCRIPTEN_PLATFORM_ -D_IRR_COMPILE_WITH_EGL_MANAGER_)
+ 	set(LINUX_PLATFORM TRUE)
+@@ -216,11 +211,7 @@ if(ENABLE_OPENGL)
+ 	find_package(OpenGL REQUIRED)
+ endif()
+ if(USE_SDL2)
+-	if(NOT ANDROID)
+-		find_package(SDL2 REQUIRED)
+-	else()
+-		# provided by AndroidLibs.cmake
+-	endif()
++	find_package(SDL2 REQUIRED)
+ 	message(STATUS "Found SDL2: ${SDL2_LIBRARIES}")
+ 
+ 	# unfortunately older SDL does not provide its version to cmake, so check header.
+@@ -263,7 +254,7 @@ endif()
+ 
+ # Platform-specific libs
+ 
+-if(ANDROID)
++if(THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 	enable_language(C)
+ elseif(APPLE)
+ 	find_library(COCOA_LIB Cocoa REQUIRED)
+@@ -497,8 +488,6 @@ target_link_libraries(IrrlichtMt PRIVATE
+ 	"$<$<BOOL:${OPENGL_DIRECT_LINK}>:${OPENGL_LIBRARIES}>"
+ 	${EGL_LIBRARY}
+ 
+-	# incl. transitive SDL2 dependencies for static linking
+-	"$<$<PLATFORM_ID:Android>:-landroid -llog -lGLESv2 -lGLESv1_CM -lOpenSLES>"
+ 	${COCOA_LIB}
+ 	${IOKIT_LIB}
+ 	"$<$<PLATFORM_ID:Windows>:gdi32>"
+@@ -513,6 +502,3 @@ endif()
+ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+ 	target_compile_definitions(IrrlichtMt INTERFACE _DEBUG) # same
+ endif()
+-if(APPLE OR ANDROID OR EMSCRIPTEN)
+-	target_compile_definitions(IrrlichtMt PUBLIC IRR_MOBILE_PATHS)
+-endif()
+diff --git a/lib/catch2/catch_amalgamated.hpp b/lib/catch2/catch_amalgamated.hpp
+index 6cc67e76f..4105fba9a 100644
+--- a/lib/catch2/catch_amalgamated.hpp
++++ b/lib/catch2/catch_amalgamated.hpp
+@@ -9046,7 +9046,7 @@ namespace Catch {
+ #define CATCH_CONFIG_ANDROID_LOGWRITE_HPP_INCLUDED
+ 
+ 
+-#if defined(__ANDROID__)
++#if defined(THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ #    define CATCH_INTERNAL_CONFIG_ANDROID_LOGWRITE
+ #endif
+ 
+diff --git a/lib/lua/src/llex.c b/lib/lua/src/llex.c
+index 5affe7c16..e5285f88f 100644
+--- a/lib/lua/src/llex.c
++++ b/lib/lua/src/llex.c
+@@ -178,11 +178,11 @@ static void buffreplace (LexState *ls, char from, char to) {
+ 
+ static void trydecpoint (LexState *ls, SemInfo *seminfo) {
+   /* format error: try to update decimal point separator */
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+   struct lconv *cv = localeconv();
+ #endif
+   char old = ls->decpoint;
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+   ls->decpoint = (cv ? cv->decimal_point[0] : '.');
+ #else
+   ls->decpoint = '.';
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 2275a2075..f654bb80c 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -329,9 +329,6 @@ else()
+ 		set(PLATFORM_LIBS ${PLATFORM_LIBS} network)
+ 	endif()
+ 
+-	if (ANDROID)
+-		set(PLATFORM_LIBS ${PLATFORM_LIBS} android log)
+-	endif()
+ endif()
+ 
+ # On clang and gcc, some functionalities of std::atomic require -latomic.
+@@ -467,10 +464,6 @@ set(common_SRCS
+ 	${server_network_SRCS}
+ )
+ 
+-if(ANDROID)
+-	set(common_SRCS ${common_SRCS} porting_android.cpp)
+-endif()
+-
+ if(BUILD_UNITTESTS)
+ 	add_subdirectory(unittest)
+ 	set(common_SRCS ${common_SRCS} ${UNITTEST_SRCS})
+@@ -556,9 +549,6 @@ include_directories(SYSTEM
+ 	${GMP_INCLUDE_DIR}
+ 	${JSON_INCLUDE_DIR}
+ 	${LUA_BIT_INCLUDE_DIR}
+-	# on Android, Luanti depends on SDL2 directly
+-	# on other platforms, only IrrlichtMt depends on SDL2
+-	"$<$<PLATFORM_ID:Android>:${SDL2_INCLUDE_DIRS}>"
+ )
+ 
+ if(USE_GETTEXT)
+@@ -600,7 +590,7 @@ endif()
+ 
+ if(BUILD_CLIENT)
+ 	# client target
+-	if(ANDROID)
++	if(THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 		add_library(${PROJECT_NAME} SHARED)
+ 	else()
+ 		add_executable(${PROJECT_NAME})
+@@ -993,7 +983,7 @@ macro(CreateLegacyAlias _cmake_target _old_path _new_name)
+ 	install(PROGRAMS "${_old_path}" DESTINATION ${BINDIR})
+ endmacro()
+ 
+-if(BUILD_CLIENT AND NOT ANDROID)
++if(BUILD_CLIENT AND NOT THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 	install(TARGETS ${PROJECT_NAME}
+ 		RUNTIME DESTINATION ${BINDIR}
+ 		LIBRARY DESTINATION ${BINDIR}
+@@ -1031,7 +1021,7 @@ if(BUILD_SERVER)
+ 	endif()
+ endif()
+ 
+-if (ANDROID)
++if (THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 	# Android does this manually in app/build.gradle -> prepareAssets
+ 	# for now!
+ elseif (USE_GETTEXT)
+diff --git a/src/client/game.cpp b/src/client/game.cpp
+index 27b58334f..629c1c7f7 100644
+--- a/src/client/game.cpp
++++ b/src/client/game.cpp
+@@ -151,7 +151,7 @@ struct LocalFormspecHandler : public TextDest
+ 
+ 			if (fields.find("btn_exit_os") != fields.end()) {
+ 				g_gamecallback->exitToOS();
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 				RenderingEngine::get_raw_device()->closeDevice();
+ #endif
+ 				return;
+@@ -800,7 +800,7 @@ class Game {
+ 		return input->wasKeyReleased(k);
+ 	}
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	void handleAndroidChatInput();
+ #endif
+ 
+@@ -944,7 +944,7 @@ class Game {
+ 	inline bool isTouchCrosshairDisabled() {
+ 		return !m_touch_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST;
+ 	}
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	bool m_android_chat_open;
+ #endif
+ 
+@@ -2032,7 +2032,7 @@ void Game::processUserInput(f32 dtime)
+ 	// Input handler step() (used by the random input generator)
+ 	input->step(dtime);
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	auto formspec = m_game_ui->getFormspecGUI();
+ 	if (formspec)
+ 		formspec->getAndroidUIInput();
+@@ -2063,7 +2063,7 @@ void Game::processKeyInput()
+ 	} else if (wasKeyDown(KeyType::INVENTORY)) {
+ 		openInventory();
+ 	} else if (input->cancelPressed()) {
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 		m_android_chat_open = false;
+ #endif
+ 		if (!gui_chat_console->isOpenInhibited()) {
+@@ -2278,7 +2278,7 @@ void Game::openConsole(float scale, const wchar_t *line)
+ {
+ 	assert(scale > 0.0f && scale <= 1.0f);
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	if (!porting::hasPhysicalKeyboardAndroid()) {
+ 		porting::showTextInputDialog("", "", 2);
+ 		m_android_chat_open = true;
+@@ -2291,12 +2291,12 @@ void Game::openConsole(float scale, const wchar_t *line)
+ 		gui_chat_console->setCloseOnEnter(true);
+ 		gui_chat_console->replaceAndAddToHistory(line);
+ 	}
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	} // else
+ #endif
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ void Game::handleAndroidChatInput()
+ {
+ 	// It has to be a text input
+@@ -4504,7 +4504,7 @@ void Game::showPauseMenu()
+ 		os << "field[4.95,0;5,1.5;;" << strgettext("Game paused") << ";]";
+ 	}
+ 
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ #if USE_SOUND
+ 	if (g_settings->getBool("enable_sound")) {
+ 		os << "button_exit[4," << (ypos++) << ";3,0.5;btn_sound;"
+diff --git a/src/client/hud.cpp b/src/client/hud.cpp
+index 2da9efa5e..b6db1be99 100644
+--- a/src/client/hud.cpp
++++ b/src/client/hud.cpp
+@@ -393,7 +393,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
+ 				if (e->size.X > 0)
+ 					font_size *= e->size.X;
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 				// The text size on Android is not proportional with the actual scaling
+ 				// FIXME: why do we have such a weird unportable hack??
+ 				if (font_size > 3 && e->offset.X < -20)
+diff --git a/src/client/renderingengine.cpp b/src/client/renderingengine.cpp
+index 4e45bd4cd..c0ae0649e 100644
+--- a/src/client/renderingengine.cpp
++++ b/src/client/renderingengine.cpp
+@@ -163,7 +163,7 @@ RenderingEngine::RenderingEngine(MyEventReceiver *receiver)
+ 
+ 	// Resolution selection
+ 	bool fullscreen = g_settings->getBool("fullscreen");
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	u16 screen_w = 0, screen_h = 0;
+ 	bool window_maximized = false;
+ #else
+@@ -328,7 +328,7 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
+ 				tsrc->getTexture("progress_bar_bg.png");
+ 
+ 		if (progress_img && progress_img_bg) {
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 			const core::dimension2d<u32> &img_size =
+ 					progress_img_bg->getSize();
+ 			float density = g_settings->getFloat("gui_scaling", 0.5f, 20.0f) *
+@@ -419,14 +419,14 @@ const VideoDriverInfo &RenderingEngine::getVideoDriverInfo(irr::video::E_DRIVER_
+ float RenderingEngine::getDisplayDensity()
+ {
+ 	float user_factor = g_settings->getFloat("display_density_factor", 0.5f, 5.0f);
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	float dpi = get_raw_device()->getDisplayDensity();
+ 	if (dpi == 0.0f)
+ 		dpi = 96.0f;
+ 	return std::max(dpi / 96.0f * user_factor, 0.5f);
+-#else // __ANDROID__
++#else // THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	return porting::getDisplayDensity() * user_factor;
+-#endif // __ANDROID__
++#endif // THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ }
+ 
+ void RenderingEngine::autosaveScreensizeAndCo(
+diff --git a/src/defaultsettings.cpp b/src/defaultsettings.cpp
+index 7758c96bf..6a14d0a8e 100644
+--- a/src/defaultsettings.cpp
++++ b/src/defaultsettings.cpp
+@@ -14,7 +14,7 @@
+ 
+ 
+ /*
+- * inspired by https://github.com/systemd/systemd/blob/7aed43437175623e0f3ae8b071bbc500c13ce893/src/hostname/hostnamed.c#L406
++ * inspired by https://github.com/systemd/systemd/blob/7aed4343`7175623e0f3ae8b071bbc500c13ce893/src/hostname/hostnamed.c#L406
+  * this could be done in future with D-Bus using query:
+  * busctl get-property org.freedesktop.hostname1 /org/freedesktop/hostname1 org.freedesktop.hostname1 Chassis
+  */
+@@ -83,7 +83,7 @@ void set_default_settings()
+ 	// Client
+ 	settings->setDefault("address", "");
+ 	settings->setDefault("enable_sound", "true");
+-#if defined(__unix__) && !defined(__APPLE__) && !defined (__ANDROID__)
++#if defined(__unix__) && !defined(__APPLE__) && !defined (THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 	// On Linux+X11 (not Linux+Wayland or Linux+XWayland), I've encountered a bug
+ 	// where fake mouse events were generated from touch events if in relative
+ 	// mouse mode, resulting in the touchscreen controls being instantly disabled
+@@ -401,7 +401,7 @@ void set_default_settings()
+ 	settings->setDefault("contentdb_enable_updates_indicator", "true");
+ 	settings->setDefault("contentdb_max_concurrent_downloads", "3");
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	settings->setDefault("contentdb_flag_blacklist", "nonfree, android_default");
+ #else
+ 	settings->setDefault("contentdb_flag_blacklist", "nonfree, desktop_default");
+@@ -553,9 +553,6 @@ void set_default_settings()
+ 	settings->setDefault("touch_punch_gesture", "short_tap");
+ 	settings->setDefault("clickable_chat_weblinks", "true");
+ 	// Altered settings for Android
+-#ifdef __ANDROID__
+-	settings->setDefault("screen_w", "0");
+-	settings->setDefault("screen_h", "0");
+ 	settings->setDefault("performance_tradeoffs", "true");
+ 	settings->setDefault("max_simultaneous_block_sends_per_client", "10");
+ 	settings->setDefault("emergequeue_limit_diskonly", "16");
+@@ -570,6 +567,9 @@ void set_default_settings()
+ 	settings->setDefault("enable_post_processing", "false");
+ 	settings->setDefault("debanding", "false");
+ 	settings->setDefault("curl_verify_cert", "false");
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
++	settings->setDefault("screen_w", "0");
++	settings->setDefault("screen_h", "0");
+ 
+ 	// Apply settings according to screen size
+ 	float x_inches = (float) porting::getDisplaySize().X /
+diff --git a/src/filesys.cpp b/src/filesys.cpp
+index 8881eb2ca..9d4f94bf3 100644
+--- a/src/filesys.cpp
++++ b/src/filesys.cpp
+@@ -436,7 +436,7 @@ std::string TempPath()
+ 		configuration hardcodes mkstemp("/tmp/lua_XXXXXX").
+ 	*/
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	return porting::path_cache;
+ #else
+ 	return DIR_DELIM "tmp";
+diff --git a/src/gui/guiEngine.cpp b/src/gui/guiEngine.cpp
+index 912bdbc75..fbb90980b 100644
+--- a/src/gui/guiEngine.cpp
++++ b/src/gui/guiEngine.cpp
+@@ -375,7 +375,7 @@ void GUIEngine::run()
+ 		sound_volume_control(m_sound_manager.get(), device->isWindowActive());
+ 		m_sound_manager->step(dtime);
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 		m_menu->getAndroidUIInput();
+ #endif
+ 	}
+diff --git a/src/gui/guiFormSpecMenu.cpp b/src/gui/guiFormSpecMenu.cpp
+index ed1c3009d..785102145 100644
+--- a/src/gui/guiFormSpecMenu.cpp
++++ b/src/gui/guiFormSpecMenu.cpp
+@@ -3326,7 +3326,7 @@ void GUIFormSpecMenu::legacySortElements(std::list<IGUIElement *>::iterator from
+ 	reorderChildren(from, to, elements);
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ void GUIFormSpecMenu::getAndroidUIInput()
+ {
+ 	porting::AndroidDialogState dialogState = getAndroidUIInputState();
+diff --git a/src/gui/guiFormSpecMenu.h b/src/gui/guiFormSpecMenu.h
+index 5c3fcd80d..3f6ffcffc 100644
+--- a/src/gui/guiFormSpecMenu.h
++++ b/src/gui/guiFormSpecMenu.h
+@@ -277,7 +277,7 @@ class GUIFormSpecMenu : public GUIModalMenu
+ 	// This will only return a meaningful value if called after drawMenu().
+ 	core::rect<s32> getAbsoluteRect();
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	void getAndroidUIInput();
+ #endif
+ 
+diff --git a/src/gui/guiOpenURL.cpp b/src/gui/guiOpenURL.cpp
+index 7ce79b0e5..01a2a1f12 100644
+--- a/src/gui/guiOpenURL.cpp
++++ b/src/gui/guiOpenURL.cpp
+@@ -153,7 +153,7 @@ void GUIOpenURLMenu::drawMenu()
+ 	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+ 
+ 	gui::IGUIElement::draw();
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	getAndroidUIInput();
+ #endif
+ }
+diff --git a/src/gui/guiPasswordChange.cpp b/src/gui/guiPasswordChange.cpp
+index a9b73dfe8..6e2cf13ca 100644
+--- a/src/gui/guiPasswordChange.cpp
++++ b/src/gui/guiPasswordChange.cpp
+@@ -154,7 +154,7 @@ void GUIPasswordChange::drawMenu()
+ 	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+ 
+ 	gui::IGUIElement::draw();
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	getAndroidUIInput();
+ #endif
+ }
+@@ -250,7 +250,7 @@ std::string GUIPasswordChange::getNameByID(s32 id)
+ 	return "";
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ void GUIPasswordChange::getAndroidUIInput()
+ {
+ 	porting::AndroidDialogState dialogState = getAndroidUIInputState();
+diff --git a/src/gui/guiPasswordChange.h b/src/gui/guiPasswordChange.h
+index 8dc670cc2..ef65205e2 100644
+--- a/src/gui/guiPasswordChange.h
++++ b/src/gui/guiPasswordChange.h
+@@ -44,7 +44,7 @@ class GUIPasswordChange : public GUIModalMenu
+ 	bool processInput();
+ 
+ 	bool OnEvent(const SEvent &event);
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	void getAndroidUIInput();
+ #endif
+ 
+diff --git a/src/gui/modalMenu.cpp b/src/gui/modalMenu.cpp
+index 0a130e905..b25707ef5 100644
+--- a/src/gui/modalMenu.cpp
++++ b/src/gui/modalMenu.cpp
+@@ -38,7 +38,7 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
+ 	s32 id, IMenuManager *menumgr, bool remap_click_outside) :
+ 		IGUIElement(gui::EGUIET_ELEMENT, env, parent, id,
+ 				core::rect<s32>(0, 0, 100, 100)),
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 		m_jni_field_name(""),
+ #endif
+ 		m_menumgr(menumgr),
+@@ -242,7 +242,7 @@ void GUIModalMenu::leave()
+ 
+ bool GUIModalMenu::preprocessEvent(const SEvent &event)
+ {
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	// display software keyboard when clicking edit boxes
+ 	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
+ 			event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN &&
+@@ -369,7 +369,7 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
+ 	return false;
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ porting::AndroidDialogState GUIModalMenu::getAndroidUIInputState()
+ {
+ 	// No dialog is shown
+diff --git a/src/gui/modalMenu.h b/src/gui/modalMenu.h
+index 62cbcfc1d..d91457b5e 100644
+--- a/src/gui/modalMenu.h
++++ b/src/gui/modalMenu.h
+@@ -7,7 +7,7 @@
+ #include "irrlichttypes_extrabloated.h"
+ #include "irr_ptr.h"
+ #include "util/string.h"
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	#include <porting_android.h>
+ #endif
+ 
+@@ -49,7 +49,7 @@ class GUIModalMenu : public gui::IGUIElement
+ 	virtual bool preprocessEvent(const SEvent &event);
+ 	virtual bool OnEvent(const SEvent &event) { return false; };
+ 	virtual bool pausesGame() { return false; } // Used for pause menu
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	virtual void getAndroidUIInput() {};
+ 	porting::AndroidDialogState getAndroidUIInputState();
+ #endif
+@@ -66,7 +66,7 @@ class GUIModalMenu : public gui::IGUIElement
+ 
+ 	v2u32 m_screensize_old;
+ 	float m_gui_scale;
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	std::string m_jni_field_name;
+ #endif
+ 
+diff --git a/src/log.cpp b/src/log.cpp
+index 144504660..85ac29604 100644
+--- a/src/log.cpp
++++ b/src/log.cpp
+@@ -14,7 +14,7 @@
+ #include "util/numeric.h"
+ #include "filesys.h"
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ #include <android/log.h>
+ #endif
+ 
+@@ -59,7 +59,7 @@ class LevelTarget : public LogTarget {
+ 
+ Logger g_logger;
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ AndroidLogOutput stdout_output;
+ AndroidLogOutput stderr_output;
+ #else
+@@ -88,7 +88,7 @@ thread_local LogStream derr_con(verbose_target);
+ thread_local LogStream dout_con(trace_target);
+ 
+ // Android
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 
+ constexpr static unsigned int g_level_to_android[] = {
+ 	ANDROID_LOG_INFO,     // LL_NONE
+diff --git a/src/log_internal.h b/src/log_internal.h
+index 512a57949..7fd79d88e 100644
+--- a/src/log_internal.h
++++ b/src/log_internal.h
+@@ -186,14 +186,14 @@ class CaptureLogOutput : public ILogOutput {
+ };
+ 
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ class AndroidLogOutput : public ICombinedLogOutput {
+ public:
+ 	void logRaw(LogLevel lev, std::string_view line);
+ };
+ #endif
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ extern AndroidLogOutput stdout_output;
+ extern AndroidLogOutput stderr_output;
+ #else
+diff --git a/src/main.cpp b/src/main.cpp
+index 6d30b2f07..ddbd631d3 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -543,7 +543,7 @@ static bool create_userdata_path()
+ {
+ 	bool success;
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	if (!fs::PathExists(porting::path_user)) {
+ 		success = fs::CreateDir(porting::path_user);
+ 	} else {
+@@ -596,7 +596,7 @@ namespace {
+ 
+ static bool use_debugger(int argc, char *argv[])
+ {
+-#if defined(__ANDROID__)
++#if defined(THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 	return false;
+ #else
+ #ifdef _WIN32
+diff --git a/src/porting.cpp b/src/porting.cpp
+index f0e2bee0b..6576fefbf 100644
+--- a/src/porting.cpp
++++ b/src/porting.cpp
+@@ -25,7 +25,7 @@
+ #if !defined(_WIN32)
+ 	#include <unistd.h>
+ 	#include <sys/utsname.h>
+-	#if !defined(__ANDROID__)
++	#if !defined(THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 		#include <spawn.h>
+ 	#endif
+ #endif
+@@ -33,7 +33,7 @@
+ 	#define _PSTAT64
+ 	#include <sys/pstat.h>
+ #endif
+-#if defined(__ANDROID__)
++#if defined(THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 	#include "porting_android.h"
+ 	#include <android/api-level.h>
+ #endif
+@@ -241,7 +241,7 @@ static std::string detectSystemInfo()
+ 	delete[] filePath;
+ 
+ 	return oss.str();
+-#elif defined(__ANDROID__)
++#elif defined(THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 	std::ostringstream oss;
+ 	struct utsname osinfo;
+ 	uname(&osinfo);
+@@ -461,7 +461,7 @@ bool setSystemPaths()
+ 
+ //// Android
+ 
+-#elif defined(__ANDROID__)
++#elif defined(THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 
+ extern bool setSystemPaths(); // defined in porting_android.cpp
+ 
+@@ -661,7 +661,7 @@ void initializePaths()
+ 	if (!setSystemPaths())
+ 		errorstream << "Failed to get one or more system-wide path" << std::endl;
+ 
+-#  ifdef __ANDROID__
++#  ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	sanity_check(!path_cache.empty());
+ #  elif defined(_WIN32)
+ 	path_cache = path_user + DIR_DELIM + "cache";
+@@ -761,7 +761,7 @@ bool secure_rand_fill_buf(void *buf, size_t len)
+ 
+ #endif
+ 
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 
+ void osSpecificInit()
+ {
+@@ -860,7 +860,7 @@ int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...)
+ 	return c;
+ }
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ // defined in porting_android.cpp
+ extern void openURIAndroid(const char *url);
+ #endif
+@@ -874,7 +874,7 @@ static bool open_uri(const std::string &uri)
+ 
+ #if defined(_WIN32)
+ 	return (intptr_t)ShellExecuteA(NULL, NULL, uri.c_str(), NULL, NULL, SW_SHOWNORMAL) > 32;
+-#elif defined(__ANDROID__)
++#elif defined(THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 	openURIAndroid(uri.c_str());
+ 	return true;
+ #elif defined(__APPLE__)
+diff --git a/src/porting.h b/src/porting.h
+index edbc236a8..430e9050f 100644
+--- a/src/porting.h
++++ b/src/porting.h
+@@ -326,6 +326,6 @@ bool open_directory(const std::string &path);
+ 
+ } // namespace porting
+ 
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ #include "porting_android.h"
+ #endif
+diff --git a/src/porting_android.cpp b/src/porting_android.cpp
+index 620d9d224..1269f7046 100644
+--- a/src/porting_android.cpp
++++ b/src/porting_android.cpp
+@@ -2,7 +2,7 @@
+ // SPDX-License-Identifier: LGPL-2.1-or-later
+ // Copyright (C) 2014 celeron55, Perttu Ahola <celeron55@gmail.com>
+ 
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ #error This file may only be compiled for android!
+ #endif
+ 
+diff --git a/src/porting_android.h b/src/porting_android.h
+index 86601f450..0565c741c 100644
+--- a/src/porting_android.h
++++ b/src/porting_android.h
+@@ -4,7 +4,7 @@
+ 
+ #pragma once
+ 
+-#ifndef __ANDROID__
++#ifndef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ #error This header has to be included on Android port only!
+ #endif
+ 
+diff --git a/src/script/lua_api/l_mainmenu.cpp b/src/script/lua_api/l_mainmenu.cpp
+index 69f63d964..bdfe5b5b9 100644
+--- a/src/script/lua_api/l_mainmenu.cpp
++++ b/src/script/lua_api/l_mainmenu.cpp
+@@ -1076,7 +1076,7 @@ int ModApiMainMenu::l_open_dir(lua_State *L)
+ /******************************************************************************/
+ int ModApiMainMenu::l_share_file(lua_State *L)
+ {
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 	std::string path = luaL_checkstring(L, 1);
+ 	porting::shareFileAndroid(path);
+ 	lua_pushboolean(L, true);
+diff --git a/src/server.cpp b/src/server.cpp
+index c9d96fa34..30803e818 100644
+--- a/src/server.cpp
++++ b/src/server.cpp
+@@ -3101,7 +3101,7 @@ std::wstring Server::handleChat(const std::string &name,
+ 			Workaround for fixing chat on Android. Lua doesn't handle
+ 			the Cyrillic alphabet and some characters on older Android devices
+ 		*/
+-#ifdef __ANDROID__
++#ifdef THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION
+ 		line += L"<" + utf8_to_wide(name) + L"> " + wmessage;
+ #else
+ 		line += utf8_to_wide(m_script->formatChatMessage(name, message));

--- a/tur/luanti/minetest-fix-elf-directory-for-cross-compiling.patch
+++ b/tur/luanti/minetest-fix-elf-directory-for-cross-compiling.patch
@@ -1,0 +1,14 @@
+Luanti seems to not have previously been exposed to cross-compiling executables
+for platforms other than SurfaceFlinger. This prevents the error
+"CMake Error: failed to create symbolic link '/minetest': Permission denied"
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -569,7 +569,7 @@ endif()
+ 
+ # When cross-compiling assume the user doesn't want to run the executable anyway,
+ # otherwise place it in <source dir>/bin/ since Luanti can only run from there.
+-if(NOT CMAKE_CROSSCOMPILING)
++if(NOT THIS_IS_FOR_SURFACEFLINGER_IN_OWOKITTYS_OPINION)
+ 	set(EXECUTABLE_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin")
+ endif()
+ 


### PR DESCRIPTION
Fixes #1295 

Tested on Samsung Galaxy S9 SM-G960U with Qualcomm Adreno 630 GPU using these commands

```
termux-x11 &
DISPLAY=:0 LIBGL_ALWAYS_SOFTWARE=1 xfce4-session &
mkdir -p ~/.minetest/games/
git clone https://git.minetest.land/VoxeLibre/VoxeLibre.git ~/.minetest/games/VoxeLibre
DISPLAY=:0 LIBGL_ALWAYS_SOFTWARE=0 MESA_LOADER_DRIVER_OVERRIDE=zink MESA_VK_WSI_DEBUG=sw luanti
```

> [!TIP]
> For this type of game (X11 window system with fully functional builtin multitouch touchscreen buttons) I recommend trying out this mode of Termux:X11 while playing:
> ![image](https://github.com/user-attachments/assets/b699793a-3c9e-4679-8e7a-e22d44f05dc9)


![Screenshot_20241107-092240_TermuxX11](https://github.com/user-attachments/assets/60a38dee-f3db-4939-8737-31cdc3f69d1a)
