### PR TITLE
fixing some packages and improving yml scripts

### DIFF
--- a/.github/workflows/package_continuous.yml
+++ b/.github/workflows/package_continuous.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
       NDK: "/opt/termux/android-ndk"
@@ -209,7 +209,7 @@ jobs:
         path: ./build-status
 
   build-1:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: prepare
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -273,7 +273,7 @@ jobs:
         path: ./build-status
 
   build-2:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-1
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -337,7 +337,7 @@ jobs:
         path: ./build-status
 
   build-3:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-2
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -401,7 +401,7 @@ jobs:
         path: ./build-status
 
   build-4:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-3
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -465,7 +465,7 @@ jobs:
         path: ./build-status
 
   build-5:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-4
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -486,8 +486,8 @@ jobs:
       run: ./setup-environment.sh
     - name: Free additional disk space
       run: |
-        sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(cabal-|dotnet-|ghc-|libmono|php|aspnetcore)') \
-          mono-runtime-common monodoc-manual ruby
+        sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|mongodb-|mysql-|php)') \
+          firefox google-chrome-stable microsoft-edge-stable mono-devel mono-runtime-common monodoc-manual ruby
         sudo apt autoremove -yq
         sudo rm -rf /opt/hostedtoolcache /usr/local /usr/share/dotnet /usr/share/swift
     - name: Download build deps
@@ -529,7 +529,7 @@ jobs:
         path: ./build-status
 
   build-6:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-5
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -593,7 +593,7 @@ jobs:
         path: ./build-status
 
   build-7:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-6
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -657,7 +657,7 @@ jobs:
         path: ./build-status
 
   build-8:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-7
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -721,7 +721,7 @@ jobs:
         path: ./build-status
 
   build-9:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-8
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -785,7 +785,7 @@ jobs:
         path: ./build-status
 
   finished-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-9
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
@@ -864,7 +864,7 @@ jobs:
           done
 
   trigeer:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name != 'pull_request' && github.ref != 'refs/heads/dev' && !startsWith(github.ref, 'refs/heads/dev/')
     needs: finished-build
     steps:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ANDROID_HOME: "/opt/termux/android-sdk"
       NDK: "/opt/termux/android-ndk"
@@ -170,9 +170,9 @@ jobs:
         done
     - name: Free additional disk space (if necessary)
       run: |
-        if grep -Eq '^(chromium|code-server|code-oss|electron-headers-.*|rustc-nightly|python-polars)$' ./built_tur_packages.txt; then
-          sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(cabal-|dotnet-|ghc-|libmono|php|aspnetcore)') \
-            mono-runtime-common monodoc-manual ruby
+        if grep -Eq "^($(paste -s -d '|' ./big-pkgs.list))$" ./built_tur_packages.txt; then
+          sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|mongodb-|mysql-|php)') \
+            firefox google-chrome-stable microsoft-edge-stable mono-devel mono-runtime-common monodoc-manual ruby
           sudo apt autoremove -yq
           sudo rm -rf /opt/hostedtoolcache /usr/local /usr/share/dotnet /usr/share/swift
         fi

--- a/big-pkgs.list
+++ b/big-pkgs.list
@@ -1,0 +1,6 @@
+chromium
+code-server
+code-oss
+electron-headers-.*
+rustc-nightly
+python-polars

--- a/tur-continuous/electron/build.sh
+++ b/tur-continuous/electron/build.sh
@@ -96,7 +96,7 @@ termux_step_configure() {
 
 	# Dummy librt.so
 	# Why not dummy a librt.a? Some of the binaries reference symbols only exists in Android
-	# for some reason, such as the `chrome_crashpad_handler`, which needs to link with 
+	# for some reason, such as the `chrome_crashpad_handler`, which needs to link with
 	# libprotobuf_lite.a, but it is hard to remove the usage of `android/log.h` in protobuf.
 	echo "INPUT(-llog -liconv -landroid-shmem)" > "$TERMUX_PREFIX/lib/librt.so"
 

--- a/tur/rustc-nightly/build.sh
+++ b/tur/rustc-nightly/build.sh
@@ -46,15 +46,15 @@ termux_pkg_auto_update() {
 
 	if [[ "${latest_version}" == "${TERMUX_PKG_VERSION}" ]]; then
 		echo "INFO: No update needed. Already at version '${TERMUX_PKG_VERSION}'."
-  		rm -rf ~/.cargo ~/.rustup
+		rm -rf ~/.cargo ~/.rustup
 		return
 	elif [ "$(echo "$latest_version $TERMUX_PKG_VERSION" | tr " " "\n" | sort -V | head -n 1)" == "$latest_version" ]; then
 		echo "Error: It seems that rustc-nightly version $latest_version is withdrawed."
-  		rm -rf ~/.cargo ~/.rustup
+		rm -rf ~/.cargo ~/.rustup
 		exit 1
 	fi
- 
-  	rm -rf ~/.cargo ~/.rustup
+
+	rm -rf ~/.cargo ~/.rustup
 	termux_pkg_upgrade_version "$latest_version"
 }
 


### PR DESCRIPTION
- made minor changes to `electron` and `rustc-nightly` packages so they pass the check by `scripts/lint-packages.sh` (fixing https://github.com/termux-pacman/tur/issues/2 and https://github.com/termux-pacman/tur/issues/5)
- changed ubuntu version (from 22.04 to 24.04) in yml scripts
- added `big-pkgs.list` file for correct operation of mirror repository

I'll note that it's not just `electron` and `rustc-nightly` that have compilation issues. There are also issues with `supertuxkart`, `libandroid-mathlib`, `electron-headers-for-code-oss` and `dd_rescue` (though with the latter, it's probably a problem with the Termux-Pacman service algorithms). You can find all the information here - https://github.com/termux-pacman/tur/issues.