### PR TITLE
chromium: revbump

### DIFF
--- a/tur/chromium/build.sh
+++ b/tur/chromium/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Chromium web browser"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="Chongyun Lee <uchkks@protonmail.com>"
 TERMUX_PKG_VERSION=125.0.6422.141
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$TERMUX_PKG_VERSION.tar.xz
 TERMUX_PKG_SHA256=9966b50279d0cfaaf4b58570387f0d526388f8d5f6dd990e3f083a55d8d8e603
 TERMUX_PKG_DEPENDS="atk, cups, dbus, gtk3, krb5, libc++, libevdev, libxkbcommon, libminizip, libnss, libwayland, libx11, mesa, openssl, pango, pulseaudio, libdrm, libjpeg-turbo, libpng, libwebp, libflac, fontconfig, freetype, zlib, libxml2, libxslt, libopus, libsnappy"


### PR DESCRIPTION
Closes #1182 
Closes termux-user-repository/chromium-builder#33
