### PR TITLE
fix(tur/archisteamfarm): shutdown dotnet build server

### DIFF
--- a/tur/archisteamfarm/build.sh
+++ b/tur/archisteamfarm/build.sh
@@ -20,6 +20,7 @@ termux_step_pre_configure() {
 
 termux_step_make() {
 	./cc.sh
+	dotnet build-server shutdown
 }
 
 termux_step_make_install() {


### PR DESCRIPTION
Fix "ERROR: Another build is already running within same environment."

[no ci]