### PR TITLE
addpkg(tur/payload-dumper-go): 1.3.0

### DIFF
--- a/tur/payload-dumper-go/0001-gozstd-fetch-source.patch
+++ b/tur/payload-dumper-go/0001-gozstd-fetch-source.patch
@@ -1,0 +1,18 @@
+--- a/vendor/github.com/valyala/gozstd/Makefile
++++ b/vendor/github.com/valyala/gozstd/Makefile
+@@ -70,12 +70,14 @@
+ 	rm -f $(LIBZSTD_NAME)
+ 	cd zstd && $(MAKE) clean
+ 
+-update-zstd:
++update-zstd-source:
+ 	rm -rf zstd-tmp
+ 	git clone --branch $(ZSTD_VERSION) --depth 1 https://github.com/Facebook/zstd zstd-tmp
+ 	rm -rf zstd-tmp/.git
+ 	rm -rf zstd
+ 	mv zstd-tmp zstd
++
++update-zstd: update-zstd-source
+ 	$(MAKE) clean libzstd.a
+ 	cp zstd/lib/zstd.h .
+ 	cp zstd/lib/zdict.h .

--- a/tur/payload-dumper-go/0002-gozstd-support-i686.patch
+++ b/tur/payload-dumper-go/0002-gozstd-support-i686.patch
@@ -1,0 +1,9 @@
+--- /dev/null
++++ b/vendor/github.com/valyala/gozstd/libzstd_linux_386.go
+@@ -0,0 +1,6 @@
++package gozstd
++
++/*
++#cgo LDFLAGS: ${SRCDIR}/libzstd_linux_386.a
++*/
++import "C"

--- a/tur/payload-dumper-go/build.sh
+++ b/tur/payload-dumper-go/build.sh
@@ -6,10 +6,28 @@ TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_SRCURL=https://github.com/ssut/payload-dumper-go/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=d7ba33a80c539674c0b63443b8c6dd9c2040ec996323f38ffe72e024d302eb2d
 TERMUX_PKG_BUILD_IN_SRC=true
-TERMUX_PKG_BUILD_DEPENDS="xz-utils"
-TERMUX_PKG_DEPENDS="xz-utils"
+TERMUX_PKG_DEPENDS="liblzma"
+
+__prepare_zstd() {
+	pushd "$TERMUX_PKG_SRCDIR"
+	cd vendor/github.com/valyala/gozstd
+	make update-zstd-source
+	cd zstd/lib
+	ZSTD_LEGACY_SUPPORT=0 MOREFLAGS=-fPIC make clean libzstd.a -j $TERMUX_PKG_MAKE_PROCESSES
+	cd ../..
+	mv zstd/lib/libzstd.a libzstd_linux_$GOARCH.a
+	popd
+}
+
+termux_step_post_get_source() {
+	termux_setup_golang
+
+	go mod vendor
+}
 
 termux_step_make() {
+	__prepare_zstd
+
 	termux_setup_golang
 	go build -o payload-dumper-go
 }

--- a/tur/payload-dumper-go/build.sh
+++ b/tur/payload-dumper-go/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/ssut/payload-dumper-go"
+TERMUX_PKG_DESCRIPTION="An android OTA payload dumper written in Go"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_VERSION="1.3.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_SRCURL=https://github.com/ssut/payload-dumper-go/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=d7ba33a80c539674c0b63443b8c6dd9c2040ec996323f38ffe72e024d302eb2d
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_BUILD_DEPENDS="xz-utils"
+TERMUX_PKG_DEPENDS="xz-utils"
+
+termux_step_make() {
+	termux_setup_golang
+	go build -o payload-dumper-go
+}
+
+termux_step_make_install() {
+	install -Dm700 -t "${TERMUX_PREFIX}"/bin payload-dumper-go
+}


### PR DESCRIPTION
This package only supports ARM and ARM64 and does not support other architectures.