### PR TITLE
fix(tur-on-device/bazel5): cherry-pick upb clang compatibility patch

### DIFF
--- a/tur-on-device/bazel5/0005-import-termux-patches.patch
+++ b/tur-on-device/bazel5/0005-import-termux-patches.patch
@@ -22,13 +22,14 @@
          "used_in": [
              "additional_distfiles",
              "test_WORKSPACE_files",
-@@ -114,6 +117,10 @@
+@@ -114,6 +117,11 @@
              "https://mirror.bazel.build/github.com/protocolbuffers/upb/archive/2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
              "https://github.com/protocolbuffers/upb/archive/2de300726a1ba2de9a468468dc5ff9ed17a3215f.tar.gz",
          ],
 +        "patch_args": ["-p1"],
 +        "patches": [
 +            "//third_party/termux-patches:upb-config.patch",
++            "//third-party/termux-patches:upb-clang-19.patch",
 +        ],
          "used_in": [
              "additional_distfiles",

--- a/tur-on-device/bazel5/build.sh
+++ b/tur-on-device/bazel5/build.sh
@@ -3,11 +3,12 @@ TERMUX_PKG_DESCRIPTION="Correct, reproducible, and fast builds for everyone"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="5.4.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/bazelbuild/bazel/releases/download/$TERMUX_PKG_VERSION/bazel-$TERMUX_PKG_VERSION-dist.zip
 TERMUX_PKG_SHA256=dcff6935756aa7aca4fc569bb2bd26e1537f0b1f6d1bda5f2b200fa835cc507f
 TERMUX_PKG_DEPENDS="libarchive, openjdk-17, patch, unzip, zip"
 TERMUX_PKG_BUILD_DEPENDS="libandroid-spawn-static, which"
-TERMUX_PKG_BREAKS="openjdk-11"
+TERMUX_PKG_BREAKS="openjdk-11, openjdk-21"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686"
 TERMUX_PKG_NO_STRIP=true
@@ -97,8 +98,8 @@ termux_step_pre_configure() {
 	__ensure_is_on_device_compile
 
 	# Ensure openjdk-17 is installed
-	# apt autoremove --purge openjdk* -y
-	# apt install --reinstall openjdk-17 -y
+	apt autoremove --purge openjdk* -y
+	apt install --reinstall openjdk-17 -y
 
 	export JAVA_HOME="$TERMUX_PREFIX/lib/jvm/java-17-openjdk"
 }

--- a/tur-on-device/bazel5/dep-patches/grpc-upb-clang-19.patch
+++ b/tur-on-device/bazel5/dep-patches/grpc-upb-clang-19.patch
@@ -1,0 +1,17 @@
+cherry-pick of https://github.com/protocolbuffers/protobuf/commit/21af7830ad5ff34798d7c5c8c70c30b450f6634e
+
+--- a/upb/port_def.inc
++++ b/upb/port_def.inc
+@@ -91,7 +91,11 @@
+ #define UPB_ALIGN_UP(size, align) (((size) + (align) - 1) / (align) * (align))
+ #define UPB_ALIGN_DOWN(size, align) ((size) / (align) * (align))
+ #define UPB_ALIGN_MALLOC(size) UPB_ALIGN_UP(size, 16)
++#ifdef __clang__
++#define UPB_ALIGN_OF(type) _Alignof(type)
++#else
+ #define UPB_ALIGN_OF(type) offsetof (struct { char c; type member; }, member)
++#endif
+ 
+ /* Hints to the compiler about likely/unlikely branches. */
+ #if defined (__GNUC__) || defined(__clang__)
+

--- a/tur-on-device/bazel5/dep-patches/grpc-upb-config.patch
+++ b/tur-on-device/bazel5/dep-patches/grpc-upb-config.patch
@@ -8,11 +8,12 @@
          # copybara:strip_end
      ],
  })
-@@ -49,6 +50,7 @@
+@@ -49,6 +50,8 @@
          "-Werror=pedantic",
          "-Wall",
          "-Wstrict-prototypes",
 +        "-Wno-gnu-offsetof-extensions",
++        "-Wno-c11-extensions",
          # GCC (at least) emits spurious warnings for this that cannot be fixed
          # without introducing redundant initialization (with runtime cost):
          #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635

--- a/tur-on-device/bazel5/dep-patches/grpc-upb.patch
+++ b/tur-on-device/bazel5/dep-patches/grpc-upb.patch
@@ -1,11 +1,12 @@
 --- a/bazel/grpc_deps.bzl
 +++ b/bazel/grpc_deps.bzl
-@@ -339,6 +343,10 @@
+@@ -339,6 +343,11 @@
          http_archive(
              name = "upb",
              sha256 = "6a5f67874af66b239b709c572ac1a5a00fdb1b29beaf13c3e6f79b1ba10dc7c4",
 +            patches = [
 +                "//third_party/termux-patches:grpc-upb-config.patch",
++                "//third_party/termux-patches:grpc-upb-clang-19.patch",
 +            ],
 +            patch_args = ["-p1"],
              strip_prefix = "upb-2de300726a1ba2de9a468468dc5ff9ed17a3215f",

--- a/tur-on-device/bazel5/dep-patches/upb-clang-19.patch
+++ b/tur-on-device/bazel5/dep-patches/upb-clang-19.patch
@@ -1,0 +1,17 @@
+cherry-pick of https://github.com/protocolbuffers/protobuf/commit/21af7830ad5ff34798d7c5c8c70c30b450f6634e
+
+--- a/upb/port_def.inc
++++ b/upb/port_def.inc
+@@ -91,7 +91,11 @@
+ #define UPB_ALIGN_UP(size, align) (((size) + (align) - 1) / (align) * (align))
+ #define UPB_ALIGN_DOWN(size, align) ((size) / (align) * (align))
+ #define UPB_ALIGN_MALLOC(size) UPB_ALIGN_UP(size, 16)
++#ifdef __clang__
++#define UPB_ALIGN_OF(type) _Alignof(type)
++#else
+ #define UPB_ALIGN_OF(type) offsetof (struct { char c; type member; }, member)
++#endif
+ 
+ /* Hints to the compiler about likely/unlikely branches. */
+ #if defined (__GNUC__) || defined(__clang__)
+

--- a/tur-on-device/bazel5/dep-patches/upb-config.patch
+++ b/tur-on-device/bazel5/dep-patches/upb-config.patch
@@ -1,6 +1,8 @@
+diff --git a/bazel/build_defs.bzl b/bazel/build_defs.bzl
+index acd474d3..cd0b6a9a 100644
 --- a/bazel/build_defs.bzl
 +++ b/bazel/build_defs.bzl
-@@ -35,6 +35,8 @@
+@@ -35,6 +35,8 @@ UPB_DEFAULT_CPPOPTS = select({
          # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
          "-Werror",
          "-Wno-long-long",
@@ -9,12 +11,13 @@
          # copybara:strip_end
      ],
  })
-@@ -49,6 +51,8 @@
+@@ -49,6 +51,9 @@ UPB_DEFAULT_COPTS = select({
          "-Werror=pedantic",
          "-Wall",
          "-Wstrict-prototypes",
 +        "-Wno-deprecated-builtins",
 +        "-Wno-gnu-offsetof-extensions",
++        "-Wno-c11-extensions",
          # GCC (at least) emits spurious warnings for this that cannot be fixed
          # without introducing redundant initialization (with runtime cost):
          #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635


### PR DESCRIPTION
- Fixes #1580

- Cherry-pick https://github.com/protocolbuffers/protobuf/commit/21af7830ad5ff34798d7c5c8c70c30b450f6634e

- Add `-Wno-c11-extensions` in the necessary places to be compatible with the cherry-pick