### PR TITLE
New pkg: gnome-sudoku

### DIFF
--- a/tur-on-device/gnome-sudoku/build.sh
+++ b/tur-on-device/gnome-sudoku/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE="https://wiki.gnome.org/Apps(2f)Sudoku.html"
+TERMUX_PKG_DESCRIPTION="GNOME Sudoku game"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION=48.0
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gnome-sudoku/${TERMUX_PKG_VERSION%.*}/gnome-sudoku-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=98c3920030dd0c2401f890c871d6345fa3c103f7069d8e583daba43558bb40b6
+TERMUX_PKG_DEPENDS="glib, gtk4, json-glib, libadwaita, libcairo, libgee, opengl, qqwing"
+TERMUX_PKG_BUILD_DEPENDS="blueprint-compiler, itstool, g-ir-scanner, gettext"
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	if [ "${TERMUX_ON_DEVICE_BUILD}" = false ]; then
+		termux_error_exit "This package doesn't support cross-compiling."
+	fi
+
+	export PYTHONDONTWRITEBYTECODE=1
+	termux_setup_gir
+}


### PR DESCRIPTION
Bringing gnome games, but I have problem: 

https://github.com/user-attachments/assets/633026bb-048a-484b-af0e-0824e5bad400

I created discussion in termux/termux-packages repo about ["How I get fully native gpu?"](https://github.com/termux/termux-packages/discussions/23961) and nobody answered because I didn't write problem description that I had no idea to write.

Or maybe opengl's issue? It lack of GLX_EXT_swap_control or GLX_MESA_swap_control that I tested with glmark2.