### PR TITLE
rustc-nightly: bump to 1.88.0-2025.04.04-nightly

### DIFF
--- a/tur/rustc-nightly/build.sh
+++ b/tur/rustc-nightly/build.sh
@@ -2,14 +2,14 @@ TERMUX_PKG_HOMEPAGE=https://www.rust-lang.org/
 TERMUX_PKG_DESCRIPTION="Rust compiler and utilities (nightly version)"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
-TERMUX_PKG_VERSION="1.87.0-2025.03.29-nightly"
+TERMUX_PKG_VERSION="1.88.0-2025.04.04-nightly"
 _RUST_VERSION=$(echo $TERMUX_PKG_VERSION | cut -d- -f1)
 _DATE="$(echo $TERMUX_PKG_VERSION | cut -d- -f2 | sed 's|\.|-|g')"
 _LLVM_MAJOR_VERSION=$(. $TERMUX_SCRIPTDIR/packages/libllvm/build.sh; echo $LLVM_MAJOR_VERSION)
 _LLVM_MAJOR_VERSION_NEXT=$((_LLVM_MAJOR_VERSION + 1))
 _LZMA_VERSION=$(. $TERMUX_SCRIPTDIR/packages/liblzma/build.sh; echo $TERMUX_PKG_VERSION)
 TERMUX_PKG_SRCURL=https://static.rust-lang.org/dist/$_DATE/rustc-nightly-src.tar.xz
-TERMUX_PKG_SHA256=e893a57175986917b5230fb2e69fef41911eea5679f0df4ab2e1fbc6e30ccb77
+TERMUX_PKG_SHA256=28eb96391277faa6514a2ffd65ce3495e5cfb13ca82b1c53f36fdbd883609160
 TERMUX_PKG_DEPENDS="clang, libandroid-execinfo, libc++, libllvm (<< ${_LLVM_MAJOR_VERSION_NEXT}), lld, openssl, zlib"
 TERMUX_PKG_BUILD_DEPENDS="wasi-libc"
 TERMUX_PKG_NO_REPLACE_GUESS_SCRIPTS=true
@@ -112,8 +112,8 @@ termux_step_pre_configure() {
 termux_step_configure() {
 	# Use nightly toolchain to build nightly toolchain
 	if [[ "${TERMUX_ON_DEVICE_BUILD}" == "false" ]]; then
-		rustup install beta
-		export PATH="${HOME}/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/bin:${PATH}"
+		rustup install nightly
+		export PATH="${HOME}/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin:${PATH}"
 	fi
 	local RUSTC=$(command -v rustc)
 	local CARGO=$(command -v cargo)

--- a/tur/rustc-nightly/config.toml
+++ b/tur/rustc-nightly/config.toml
@@ -28,6 +28,7 @@ tools = [
     "rust-demangler",
 ]
 sanitizers = false
+local-rebuild = true
 android-ndk = "@TERMUX_STANDALONE_TOOLCHAIN@"
 
 [install]


### PR DESCRIPTION
Closes #1639