### PR TITLE
New pkgs: some GNOME games

### DIFF
--- a/tur-on-device/gnome-mines/build.sh
+++ b/tur-on-device/gnome-mines/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@lunsokhasovan, @termux-user-repository"
 TERMUX_PKG_VERSION=48.1
 TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gnome-mines/${TERMUX_PKG_VERSION%.*}/gnome-mines-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=ef4b2d2dde3bec614157edde4d9189cc6afe692952a2dd55b2870e2e62ed8104
-TERMUX_PKG_DEPENDS="glib, gtk4, libadwaita, librsvg, libgnome-games-support"
+TERMUX_PKG_DEPENDS="glib, gtk4, libadwaita, libcairo, librsvg, libgnome-games-support"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, gettext, itstool"
 TERMUX_PKG_AUTO_UPDATE=true
 

--- a/tur-on-device/gnome-mines/build.sh
+++ b/tur-on-device/gnome-mines/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE="https://wiki.gnome.org/Apps/Mines"
+TERMUX_PKG_DESCRIPTION="GNOME Mines Sweeper game"
+TERMUX_PKG_LICENSE="GPL-3.0-or-later"
+TERMUX_PKG_MAINTAINER="@lunsokhasovan, @termux-user-repository"
+TERMUX_PKG_VERSION=48.1
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/gnome-mines/${TERMUX_PKG_VERSION%.*}/gnome-mines-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=ef4b2d2dde3bec614157edde4d9189cc6afe692952a2dd55b2870e2e62ed8104
+TERMUX_PKG_DEPENDS="glib, gtk4, libadwaita, librsvg, libgnome-games-support"
+TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, gettext, itstool"
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	if [ "${TERMUX_ON_DEVICE_BUILD}" = false ]; then
+		termux_error_exit "This package doesn't support cross-compiling."
+	fi
+
+	export PYTHONDONTWRITEBYTECODE=1
+	termux_setup_gir
+}

--- a/tur-on-device/lightsoff/build.sh
+++ b/tur-on-device/lightsoff/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="@lunsokhasovan, @termux-user-repository"
 TERMUX_PKG_VERSION=48.1
 TERMUX_PKG_SRCURL=https://download.gnome.org/sources/lightsoff/${TERMUX_PKG_VERSION%.*}/lightsoff-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=2ec99501713dbcd13c5a565a2e118cc4cc2b502836b387a7736cfba40a8b3989
-TERMUX_PKG_DEPENDS="glib, gtk4, libadwaita, libcairo, librsvg, libgnome-games-support, pango"
+TERMUX_PKG_DEPENDS="glib, gtk4, libadwaita, libcairo, librsvg"
 TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, gettext, itstool"
 TERMUX_PKG_AUTO_UPDATE=true
 

--- a/tur-on-device/lightsoff/build.sh
+++ b/tur-on-device/lightsoff/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE="https://wiki.gnome.org/Apps/Lightsoff"
+TERMUX_PKG_DESCRIPTION="GNOME Lightsoff game"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@lunsokhasovan, @termux-user-repository"
+TERMUX_PKG_VERSION=48.1
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/lightsoff/${TERMUX_PKG_VERSION%.*}/lightsoff-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=2ec99501713dbcd13c5a565a2e118cc4cc2b502836b387a7736cfba40a8b3989
+TERMUX_PKG_DEPENDS="glib, gtk4, libadwaita, libcairo, librsvg, libgnome-games-support, pango"
+TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, gettext, itstool"
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	if [ "${TERMUX_ON_DEVICE_BUILD}" = false ]; then
+		termux_error_exit "This package doesn't support cross-compiling."
+	fi
+
+	export PYTHONDONTWRITEBYTECODE=1
+	termux_setup_gir
+}

--- a/tur-on-device/swell-foop/build.sh
+++ b/tur-on-device/swell-foop/build.sh
@@ -1,0 +1,19 @@
+TERMUX_PKG_HOMEPAGE="https://wiki.gnome.org/Apps/Swell%20Foop"
+TERMUX_PKG_DESCRIPTION="GNOME colored tiles puzzle game"
+TERMUX_PKG_LICENSE="GPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="@lunsokhasovan, @termux-user-repository"
+TERMUX_PKG_VERSION=48.1
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/swell-foop/${TERMUX_PKG_VERSION%.*}/swell-foop-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=5b9630878fe701aee751ed46ff765c2bcd9f815a4e5582676a3c26b31182031b
+TERMUX_PKG_DEPENDS="glib, gtk4, libadwaita, libcairo, librsvg, libgnome-games-support, pango"
+TERMUX_PKG_BUILD_DEPENDS="g-ir-scanner, gettext, itstool"
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	if [ "${TERMUX_ON_DEVICE_BUILD}" = false ]; then
+		termux_error_exit "This package doesn't support cross-compiling."
+	fi
+
+	export PYTHONDONTWRITEBYTECODE=1
+	termux_setup_gir
+}

--- a/tur/libgnome-games-support-1/build.sh
+++ b/tur/libgnome-games-support-1/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE="https://gitlab.gnome.org/GNOME/libgnome-games-support/"
+TERMUX_PKG_DESCRIPTION="Support library for GNOME games"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@lunsokhasovan, @termux-user-repository"
+TERMUX_PKG_VERSION=1.8.2
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/libgnome-games-support/${TERMUX_PKG_VERSION%.*}/libgnome-games-support-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=cb6c4859d16bffc941b1098f7f624c84e6a3339fce45629e45ba8b3f653d58f9
+TERMUX_PKG_DEPENDS="glib, gtk4, libgee"
+TERMUX_PKG_BUILD_DEPENDS="gettext"

--- a/tur/libgnome-games-support/build.sh
+++ b/tur/libgnome-games-support/build.sh
@@ -1,0 +1,10 @@
+TERMUX_PKG_HOMEPAGE="https://gitlab.gnome.org/GNOME/libgnome-games-support/"
+TERMUX_PKG_DESCRIPTION="Support library for GNOME games"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@lunsokhasovan, @termux-user-repository"
+TERMUX_PKG_VERSION=2.0.1
+TERMUX_PKG_SRCURL=https://download.gnome.org/sources/libgnome-games-support/${TERMUX_PKG_VERSION%.*}/libgnome-games-support-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=0186f25c4892c86c7eac43a307fc19db696df4f19aca7f54e83c221df9d9790a
+TERMUX_PKG_DEPENDS="glib, gtk4, libgee"
+TERMUX_PKG_BUILD_DEPENDS="gettext"
+TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
I'm back with yet another some GNOME games again.

I wonder bring `gnome-shell` to Termux. I can't wait to see it with slowest llvmpipe.

If you do, maybe I can bring `nautilus` to offical Termux-packages for first time. But failed while compiling

![Screenshot_2025-04-17_12-03-16](https://github.com/user-attachments/assets/fd8c0631-0566-45c7-b8c6-ff14afc8474e)

I don't know how to fix it. I knew they can fix by modifiy file from source.