### PR TITLE
curl chrome impersonation bionic build errors HELP wanted do not merge .not ready yet.

### DIFF
--- a/tur/boringssl/build.sh
+++ b/tur/boringssl/build.sh
@@ -1,0 +1,27 @@
+
+TERMUX_PKG_DESCRIPTION="boring ssl"
+TERMUX_PKG_VERSION=0
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_SRCURL=git+https://github.com/google/boringssl
+TERMUX_PKG_GIT_BRANCH=main
+TERMUX_PKG_BUILD_DEPENDS="golang"
+# TERMUX_PKG_DEPENDS="libnghttp2, libnghttp3, libssh2, openssl (>= 1:3.2.1-1), zlib"
+TERMUX_PKG_DEPENDS="ca-certificates, zlib"
+TERMUX_PKG_MAKE_PROCESSES=4
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DCMAKE_INSTALL_PREFIX=$TERMUX_PREFIX/opt/boringssl -DBUILD_SHARED_LIBS=ON"
+# termux_step_configure() { :; }
+
+# termux_step_make() { 
+
+# }
+
+
+termux_step_post_make_install() {
+	mv $TERMUX_PREFIX
+}
+
+# termux_step_extract_into_massagedir() { :; }
+
+# termux_step_post_massage() { :; }
+
+

--- a/tur/curl-impersonate/build.sh
+++ b/tur/curl-impersonate/build.sh
@@ -1,0 +1,40 @@
+
+TERMUX_PKG_DESCRIPTION="curl impersonation for curl_cffi"
+TERMUX_PKG_VERSION=8.1.1
+TERMUX_PKG_LICENSE="MIT"
+# TERMUX_PKG_SRCURL=git+https://github.com/lwthiker/curl-impersonate
+# TERMUX_PKG_GIT_BRANCH=main
+TERMUX_PKG_SRCURL=git+https://github.com/john-peterson/curl
+TERMUX_PKG_GIT_BRANCH=imp
+TERMUX_PKG_BUILD_DEPENDS="golang"
+TERMUX_PKG_DEPENDS="boringssl, brotli, libnghttp2, libnghttp3, libssh2, zlib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" -DUSE_NGHTTP2=ON -DCURL_BROTLI=ON -DOPENSSL_ROOT_DIR=$TERMUX_PREFIX/opt/boringssl -DBUILD_SHARED_LIBS=ON  "
+# -DCMAKE_CXX_FLAGS:=-fno-exceptions
+TERMUX_PKG_MAKE_PROCESSES=4
+
+termux_step_pre_configure() {
+# export CXXFLAGS=-fno-exceptions
+export CFLAGS=-fno-exceptions
+}
+
+termux_step_post_configure() {
+	ack fno-exc build.ninja || exit
+	# exit
+:; 
+}
+
+# termux_step_make() { 
+# make chrome-build -C ../build
+# }
+
+# termux_step_make_install() {
+	# mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib
+	# cp $TERMUX_PKG_BUILDDIR/* $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib/
+	# :;
+# }
+
+# termux_step_extract_into_massagedir() { :; }
+
+# termux_step_post_massage() { :; }
+
+


### PR DESCRIPTION
 if anyone is not tired of bionic already here are some
errors -fno-exceptions should have removed the first ones.

I am going to work on a stand alone glibc repo instead and try to make
my default shell GNU I have just about had it with this maybe someone
can encourage me to explain why we need bionic at all I never use th
graphics card or system drivers anyway . or hardly ever

pip install curl_cffi for bionic is missing this lib because no one no
same person could build it in bionic

~~~sh

termux - building curl-impersonate for arch aarch64...
[1/1] Linking C executable src/curl
FAILED: src/curl
ld.lld: error: undefined reference due to --no-allow-shlib-undefined: __cxa_begin_catch
>>> referenced by lib/libcurl.so

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: std::terminate()
>>> referenced by lib/libcurl.so

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: __gxx_personality_v0
>>> referenced by lib/libcurl.so

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: __cxa_rethrow
>>> referenced by lib/libcurl.so

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: __cxa_end_catch
>>> referenced by lib/libcurl.so

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: void std::__ndk1::__sort<std::__ndk1::__less<unsigned short, unsigned short>&, unsigned short*>(unsigned short*, unsigned short*, std::__ndk1::__less<unsigned short, unsigned short>&)
>>> referenced by lib/libcurl.so

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: operator delete(void*)
>>> referenced by lib/libcurl.so

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: vtable for __cxxabiv1::__class_type_info
>>> referenced by lib/libcurl.so

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: vtable for __cxxabiv1::__si_class_type_info
>>> referenced by lib/libcurl.so
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
