### PR TITLE
addpkg(tur/erlang26-manpages): 26.2.5.11

### DIFF
--- a/tur/erlang26-manpages/build.sh
+++ b/tur/erlang26-manpages/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://www.erlang.org/
+TERMUX_PKG_DESCRIPTION="Prebuilt legacy manpages for Erlang"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="26.2.5.11"
+TERMUX_PKG_SRCURL=https://github.com/erlang/otp/releases/download/OTP-${TERMUX_PKG_VERSION}/otp_doc_man_${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=601f401b948e767f7b7ff5e139cae9579ad20fba3862da4b8da388c7965290c3
+TERMUX_PKG_SUGGESTS="erlang"
+TERMUX_PKG_BUILD_DEPENDS="rsync"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+
+termux_step_make_install() {
+	# conflicts with perl manpage
+	rm man3/re.3
+	# conflicts with zlib package
+	rm man3/zlib.3
+	# man1 directory still exists in Erlang 27.
+	# Only Erlang 26 has man3/4/6/7, enabling "erl -man io" and similar commands.
+	rsync -aI man{3,4,6,7} "$TERMUX_PREFIX/share/man/"
+}


### PR DESCRIPTION
- Fixes the rest of https://github.com/termux/termux-packages/issues/24624 by implementing the `erl -man io` command
  - Depends on https://github.com/termux/termux-packages/pull/24627 so that `erl -man` is patched to search the desired paths for man pages

- In all Erlang versions after https://github.com/erlang/otp/pull/8026, the `man3`, `man4`, `man6` and `man7` manpages no longer exist in upstream releases (Erlang 27+), so these manpages can no longer be up to date with the current Erlang releases.

- Can potentially conflict with some other packages - conflicts with `perl` and `zlib` found and resolved here