### PR TITLE
chore(tur/apkeditor): runnable latest jar

### DIFF
--- a/tur/apkeditor/build.sh
+++ b/tur/apkeditor/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Android binary resource files editor"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@Veha0001"
 TERMUX_PKG_VERSION="1.4.3"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/REAndroid/APKEditor/releases/download/V${TERMUX_PKG_VERSION}/APKEditor-${TERMUX_PKG_VERSION}.jar
 TERMUX_PKG_SHA256=c242f5fc4591667a0084668320d0016a20e7c2abae102c1bd4d640e11d9f60ee
 TERMUX_PKG_DEPENDS="openjdk-21"
@@ -15,11 +16,8 @@ TERMUX_PKG_UPDATE_VERSION_REGEXP="\d+\.\d+\.\d+"
 
 termux_step_make_install() {
 	local RAWJAR="$TERMUX_PKG_CACHEDIR/APKEditor-${TERMUX_PKG_VERSION}.jar"
-	local INSTALL_PREFIX="$TERMUX_PREFIX/libexec/apkeditor/apkeditor.jar"
-	# Download and install the jar
 	termux_download $TERMUX_PKG_SRCURL $RAWJAR $TERMUX_PKG_SHA256
-	install -Dm600 $RAWJAR $INSTALL_PREFIX
-	# Process and install the wrapper script
+	install -Dm600 $RAWJAR $TERMUX_PREFIX/libexec/apkeditor/apkeditor.jar
 	sed -e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" \
 		$TERMUX_PKG_BUILDER_DIR/wrapper.in \
 		> $TERMUX_PREFIX/bin/$TERMUX_PKG_NAME

--- a/tur/apkeditor/wrapper.in
+++ b/tur/apkeditor/wrapper.in
@@ -1,4 +1,4 @@
-#!@TERMUX_PREFIX@/bin/sh
+#!/bin/sh
 #
 # Copyright (C) 2016 The Android Open Source Project
 # Copyright (C) 2022 github.com/REAndroid
@@ -15,9 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+libdir="@TERMUX_PREFIX@/libexec/apkeditor"
 jarfile=apkeditor.jar
-jarpath="@TERMUX_PREFIX@/libexec/apkeditor/$jarfile"
+
+# Find the highest version of APKEditor-*.jar in the directory.
+highest_jarfile=$(ls "$libdir"/APKEditor-*.jar 2>/dev/null | sort -V | tail -n 1)
+if [ -n "$highest_jarfile" ]; then
+    jarfile=$(basename "$highest_jarfile")
+fi
+
+if [ ! -r "$libdir/$jarfile" ]; then
+    echo "$(basename "$0"): can't find $jarfile"
+    exit 1
+fi
 
 # By default, give apkeditor a max heap size of 1 gig. This can be overridden
 # by using a "-J" option (see below).
@@ -36,8 +46,6 @@ while expr "x$1" : 'x-J' >/dev/null; do
     javaOpts="${javaOpts} -${opt}"
     if expr "x${opt}" : "xXmx[0-9]" >/dev/null; then
         defaultMx="no"
-    elif expr "x${opt}" : "xDjava.library.path=" >/dev/null; then
-        defaultLibdir="no"
     fi
     shift
 done
@@ -46,8 +54,6 @@ if [ "${defaultMx}" != "no" ]; then
     javaOpts="${javaOpts} ${defaultMx}"
 fi
 
-if [ "${defaultLibdir}" != "no" ] && [ -n $providerLibdir ]; then
-    javaOpts="${javaOpts} -Djava.library.path=$providerLibdir"
-fi
+jarpath="$libdir/$jarfile"
 
 exec java $javaOpts -jar "$jarpath" "$@"


### PR DESCRIPTION
# Summary
- Select APKEditor-*.jar, which can be downloaded from the latest build, with the highest version in `/libexec/apkeditor`. Which can be linked anywhere btw.

- Remove an unnecessary Java argument.
