### PR TITLE
fix(tur-on-device/python2-numpy): explicitly link to `libm.so`

### DIFF
--- a/tur-on-device/python2-numpy/build.sh
+++ b/tur-on-device/python2-numpy/build.sh
@@ -3,7 +3,7 @@ TERMUX_PKG_DESCRIPTION="The fundamental package for scientific computing with Py
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="1.16.6"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://files.pythonhosted.org/packages/b7/6f/24647f014eef9b67a24adfcbcd4f4928349b4a0f8393b3d7fe648d4d2de3/numpy-$TERMUX_PKG_VERSION.zip
 TERMUX_PKG_SHA256=e5cf3fdf13401885e8eea8170624ec96225e2174eb0c611c6f26dd33b489e3ff
 TERMUX_PKG_DEPENDS="libc++, libopenblas, python2"
@@ -14,7 +14,7 @@ termux_step_pre_configure() {
 		termux_error_exit "This package doesn't support cross-compiling."
 	fi
 
-	LDFLAGS+=" -Wl,--no-as-needed -lpython2.7"
+	LDFLAGS+=" -Wl,--no-as-needed -lpython2.7 -lm"
 }
 
 termux_step_configure() {


### PR DESCRIPTION
- Fixes https://github.com/termux-user-repository/tur/issues/1781