### PR TITLE
smallerc: fix PATH problems

### DIFF
--- a/tur/smallerc/0001-make-stop-mangling-PATH.patch
+++ b/tur/smallerc/0001-make-stop-mangling-PATH.patch
@@ -1,0 +1,34 @@
+From 876cdc70e48a9ac8a9a2a9f3777659dc611a1116 Mon Sep 17 00:00:00 2001
+From: Stas Sergeev <stsp2@yandex.ru>
+Date: Sun, 6 Jul 2025 22:53:03 +0300
+Subject: [PATCH] make: stop mangling PATH
+
+This breaks cross-compilation environments.
+---
+ GNUmakefile | 1 -
+ Makefile    | 3 ---
+ 2 files changed, 4 deletions(-)
+
+diff --git a/GNUmakefile b/GNUmakefile
+index ca91e8c..64bc74f 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -1,5 +1,4 @@
+ srcdir := $(dir $(shell readlink -f \
+ 	$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))))v0100
+ VPATH = $(srcdir) $(srcdir)/srclib
+-export PATH := $(CURDIR):$(PATH)
+ include $(srcdir)/../common.mk
+diff --git a/Makefile b/Makefile
+index 9b40881..9ba9728 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,2 @@
+ srcdir != readlink -f $(.PARSEDIR)/$(.PARSEFILE) | sed 's@[^/]*$$@v0100@'
+-.PATH: $(srcdir) $(srcdir)/srclib
+-PATH := $(.CURDIR):$(PATH)
+-.export PATH
+ .include "$(srcdir)/../common.mk"
+-- 
+2.48.1
+

--- a/tur/smallerc/build.sh
+++ b/tur/smallerc/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Simple and small C compiler for DOS, Windows, Linux and 
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION=1.0.2
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/alexfru/SmallerC/archive/refs/tags/v${TERMUX_PKG_VERSION}+dos.win.b120a9c.tar.gz
 TERMUX_PKG_SHA256=1e26ed8da461614da26379b7be1510f0e39f52a292fd0d9e54d747664f0c7ef4
 TERMUX_PKG_BUILD_DEPENDS="nasm"
@@ -17,11 +18,11 @@ termux_step_host_build() {
 	make prefix=$_PREFIX_FOR_BUILD
 	make install prefix=$_PREFIX_FOR_BUILD
 	make clean
-	export PATH="$PATH:$_PREFIX_FOR_BUILD/bin"
 }
 
 termux_step_make() {
 	local _PREFIX_FOR_BUILD=${TERMUX_PREFIX}/opt/$TERMUX_PKG_NAME/cross
+	export PATH="$PATH:$_PREFIX_FOR_BUILD/bin"
 	make prefix=$PREFIX SMLRCC="${_PREFIX_FOR_BUILD}/bin/smlrcc"
 }
 


### PR DESCRIPTION
It was setting PATH in makefiles to just-built executables, failing the local build, as we need to use executables from smallerc-cross subpackage rather than the just-built ones.

Related: #1833