### PR TITLE
New pkgs: calligra, kf6-kcmutils

### DIFF
--- a/tur-on-device/calligra/build.sh
+++ b/tur-on-device/calligra/build.sh
@@ -1,0 +1,17 @@
+TERMUX_PKG_HOMEPAGE='https://calligra.org/'
+TERMUX_PKG_DESCRIPTION='Office and graphic art suite by KDE'
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="25.04.3"
+TERMUX_PKG_SRCURL=https://download.kde.org/stable/release-service/${TERMUX_PKG_VERSION}/src/calligra-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=26d75a67eca8a137849bc925da0f65f49f11c29e9fc75346cb2d6627036e6d4f
+TERMUX_PKG_DEPENDS="gsl, libc++, libgit2, libetonyek, libodfgen, librevenge, libwpd, libwpg, libwps, libvisio, littlecms, fontconfig, freetype, imath, kf6-karchive, kf6-kcmutils, kf6-kcolorscheme, kf6-kcompletion, kf6-kconfig, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kcrash, kf6-kdbusaddons, kf6-kguiaddons, kf6-ki18n, kf6-kiconthemes, kf6-kio, kf6-kitemviews, kf6-kjobwidgets, kf6-knotifications, kf6-knotifyconfig, kf6-ktextwidgets, kf6-kwidgetsaddons, kf6-kwindowsystem, kf6-kxmlgui, kf6-purpose, kf6-sonnet, kf6-solid, mediainfo, mlt, opengl, openssl, opentimelineio, perl, poppler, qt6-qtbase, qt6-qtdeclarative, qt6-qtmultimedia, qt6-qtnetworkauth, qt6-qtsvg, qca, qtkeychain, shared-mime-info, zlib"
+TERMUX_PKG_BUILD_DEPENDS="boost, eigen, extra-cmake-modules, qt6-qttools, kf6-kconfig-cross-tools"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+-DUSE_DBUS=OFF
+"

--- a/tur-on-device/calligra/disabled-kdoctools.patch
+++ b/tur-on-device/calligra/disabled-kdoctools.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2025-07-01 00:01:01.000000000 +0700
++++ b/CMakeLists.txt	2025-07-28 09:20:55.513478596 +0700
+@@ -131,7 +131,7 @@
+     ConfigWidgets
+     CoreAddons
+     Crash
+-    DocTools
++    #DocTools
+     GuiAddons
+     I18n
+     IconThemes
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+--- a/doc/CMakeLists.txt	2025-07-01 00:01:01.000000000 +0700
++++ b/doc/CMakeLists.txt	2025-07-28 09:31:40.429478134 +0700
+@@ -1,8 +1,10 @@
+-add_subdirectory(calligra)
+-if(SHOULD_BUILD_STAGE)
+-    add_subdirectory(stage)
+-endif()
+-if(SHOULD_BUILD_SHEETS)
+-    add_subdirectory(sheets)
++if(KF6DocTools_FOUND)
++    add_subdirectory(calligra)
++    if(SHOULD_BUILD_STAGE)
++        add_subdirectory(stage)
++    endif()
++    if(SHOULD_BUILD_SHEETS)
++        add_subdirectory(sheets)
++    endif()
+ endif()
+ install(FILES   calligra.desktop DESTINATION ${KDE_INSTALL_APPDIR})

--- a/tur-on-device/kf6-kcmutils/build.sh
+++ b/tur-on-device/kf6-kcmutils/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE="https://community.kde.org/Frameworks"
+TERMUX_PKG_DESCRIPTION="Utilities for interacting with KCModules (KDE)"
+TERMUX_PKG_LICENSE="LGPL-2.0, LGPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="6.16.0"
+_KF6_MINOR_VERSION="${TERMUX_PKG_VERSION%.*}"
+TERMUX_PKG_SRCURL="https://download.kde.org/stable/frameworks/${_KF6_MINOR_VERSION}/kcmutils-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=403f5eb3288ffbbc64cb6741048007dde82be390da2c50ba147cb474921e3344
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="libc++, kf6-kconfigwidgets, kf6-kcoreaddons, kf6-kguiaddons, kf6-ki18n, kf6-kitemviews, kf6-kio, kf6-kwidgetsaddons, kf6-kxmlgui, qt6-qtdeclarative, qt6-qtbase"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules (>= ${_KF6_MINOR_VERSION}), qt6-qttools"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DKF6_HOST_TOOLING=$TERMUX_PREFIX/opt/kf6/cross/lib/cmake/
+-DKDE_INSTALL_QMLDIR=lib/qt6/qml
+-DKDE_INSTALL_QTPLUGINDIR=lib/qt6/plugins
+-DUSE_DBUS=OFF
+"


### PR DESCRIPTION
Calligra is LibreOffice's alternatives. Office and graphic art suite by KDE. I created [issue on termux/termux-packages](https://github.com/termux/termux-packages/issues/25469#issue-3265735105) and no one accept. So I pull request here instead of termux/termux-packages, due to liblangtag's error (moved from tur) or [need gir file](https://github.com/lunsokhasovan/termux-packages/actions/runs/16612354802) (add g-ir-scanner) that I don't know how I make gir file.