### PR TITLE
python-scipy: rev-bump

### DIFF
--- a/tur/python-scipy/build.sh
+++ b/tur/python-scipy/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Fundamental algorithms for scientific computing in Pytho
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="1:1.16.0"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://github.com/scipy/scipy
 TERMUX_PKG_DEPENDS="libc++, libopenblas, python, python-numpy"
 TERMUX_PKG_BUILD_DEPENDS="python-numpy-static"


### PR DESCRIPTION
Version of 'python-scipy' has not changed.
Either 'TERMUX_PKG_REVISION' or 'TERMUX_PKG_VERSION' need to be modified in the build.sh when changing a package build. Alternatively you can add '[no version check]'.
To the commit message to skip this check.