### PR TITLE
fix(tur/openjdk-11): patch `TMP_BUFFER_LEN` to be relative to the build-time length of `@TERMUX_PREFIX@/tmp`

### DIFF
--- a/tur/openjdk-11/build.sh
+++ b/tur/openjdk-11/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Java development kit and runtime"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION="11.0.29"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/openjdk/jdk11u/archive/refs/tags/jdk-${TERMUX_PKG_VERSION}-ga.tar.gz
 TERMUX_PKG_SHA256=258bc09a2b1ce6d5965a1538ffaa2e2d25670ac3b75a43e7a08d210257e99bfc
 TERMUX_PKG_AUTO_UPDATE=true
@@ -59,6 +60,14 @@ termux_step_host_build() {
 
 termux_step_pre_configure() {
 	unset JAVA_HOME
+
+	local patch="$TERMUX_PKG_BUILDER_DIR/tmpdir-path-length.diff"
+	local tmpdir_path="$TERMUX_PREFIX/tmp"
+	echo "Applying patch: $(basename "$patch")"
+	test -f "$patch" && sed \
+		-e "s%\@TERMUX_PREFIX\@%${TERMUX_PREFIX}%g" \
+		-e "s%\@TERMUX_TMPDIR_PATH_LENGTH\@%${#tmpdir_path}%g" \
+		"$patch" | patch --silent -p1
 }
 
 termux_step_configure() {

--- a/tur/openjdk-11/tmpdir-path-length.diff
+++ b/tur/openjdk-11/tmpdir-path-length.diff
@@ -1,0 +1,17 @@
+--- a/src/hotspot/os/linux/perfMemory_linux.cpp
++++ b/src/hotspot/os/linux/perfMemory_linux.cpp
+@@ -145,11 +145,11 @@ static void save_memory_to_file(char* addr, size_t size) {
+ //
+ // the caller is expected to free the allocated memory.
+ //
+-#define TMP_BUFFER_LEN (4+22)
++#define TMP_BUFFER_LEN (@TERMUX_TMPDIR_PATH_LENGTH@+22)
+ static char* get_user_tmp_dir(const char* user, int vmid, int nspid) {
+   char buffer[TMP_BUFFER_LEN];
+-  char* tmpdir = (char *)os::get_temp_directory();
+-  assert(strlen(tmpdir) == 4, "No longer using /tmp - update buffer size");
++  char* tmpdir = "@TERMUX_PREFIX@/tmp";
++  assert(strlen(tmpdir) == @TERMUX_TMPDIR_PATH_LENGTH@, "No longer using @TERMUX_PREFIX@/tmp - update buffer size");
+ 
+   if (nspid != -1) {
+     jio_snprintf(buffer, TMP_BUFFER_LEN, "/proc/%d/root%s", vmid, tmpdir);


### PR DESCRIPTION
- Synchronize with https://github.com/termux/termux-packages/pull/27046

- It is also necessary to hardcode `char* tmpdir = "@TERMUX_PREFIX@/tmp";` because OpenJDK has an internal hostbuild that will crash at build-time if it is not also redirected to use `@TERMUX_PREFIX@/tmp` instead of `/tmp` simultaneously
  - This is OK because `@TERMUX_PREFIX@/tmp` is already a directory excluded from packaging globally, so it is safe to use as a tmpdir at build-time of anything

https://github.com/termux/termux-packages/blob/f7d37694465b0c2985a573df8992ec08a1873f16/scripts/build/termux_step_copy_into_massagedir.sh#L5

- The crash is only easily reproducible in `slowdebug` builds, but the same code exists possibly-dormant in every OpenJDK, so should be patched in all