### PR TITLE
fix(building-system-patches/0002-fix-auto-update): take `basename` of `realpath` to try to correct dependency skipping

### DIFF
--- a/common-files/building-system-patches/0002-fix-auto-update.patch
+++ b/common-files/building-system-patches/0002-fix-auto-update.patch
@@ -5,7 +5,7 @@ Only search packages from TUR repository when auto-updating.
  		termux_error_exit "directory '${pkg_dir}' is not a package."
  	fi
  
-+	if [[ "$(realpath "$(dirname "${pkg_dir}")")" != *"tur"* ]]; then
++	if [[ "$(basename "$(realpath "$(dirname "${pkg_dir}")")")" != *"tur"* ]]; then
 +		echo "INFO: Skipping '$(basename "${pkg_dir}")', it is not a TUR package."
 +		return 1
 +	fi


### PR DESCRIPTION
- Suspected necessary change: `/home/runner/tur/packages != *"tur"*` -> `packages != *"tur"*`

- Fixes https://github.com/termux-user-repository/tur/issues/2088

- Fixes https://github.com/termux-user-repository/tur/issues/2084

- Fixes https://github.com/termux-user-repository/tur/issues/2064

- Fixes https://github.com/termux-user-repository/tur/issues/2038

- Fixes https://github.com/termux-user-repository/tur/issues/2036

- Fixes https://github.com/termux-user-repository/tur/issues/2006

- Fixes https://github.com/termux-user-repository/tur/issues/1986

- Fixes https://github.com/termux-user-repository/tur/issues/1964

- Fixes https://github.com/termux-user-repository/tur/issues/1911

- Fixes https://github.com/termux-user-repository/tur/issues/1832

- Fixes https://github.com/termux-user-repository/tur/issues/1831

- Fixes https://github.com/termux-user-repository/tur/issues/1815

- Fixes https://github.com/termux-user-repository/tur/issues/1717

- Fixes https://github.com/termux-user-repository/tur/issues/1658

- Fixes https://github.com/termux-user-repository/tur/issues/1564

- Fixes https://github.com/termux-user-repository/tur/issues/1365