### PR TITLE
fix(ci/package_on_device): rename archive again before uploading to the temporary release

### DIFF
--- a/.github/workflows/package_on_device.yml
+++ b/.github/workflows/package_on_device.yml
@@ -284,8 +284,10 @@ jobs:
       run: |
         GITHUB_SHA=${{ github.sha }}
         for archive in debs-*/debs-{aarch64,arm,i686,x86_64}-${{ github.sha }}.tar; do
-          gh release upload -R https://github.com/termux-user-repository/tur "0.1" $archive
-          echo "$archive  uploaded"
+          tur_on_device_archive="${archive//.tar/-tur-on-device.tar}"
+          mv "$archive" "$tur_on_device_archive"
+          gh release upload -R https://github.com/termux-user-repository/tur "0.1" "$tur_on_device_archive"
+          echo "$tur_on_device_archive uploaded"
         done
     - name: Trigger workflow in dists repository
       env:


### PR DESCRIPTION
- Partially revert https://github.com/termux-user-repository/tur/pull/2115

- Reapply https://github.com/termux-user-repository/tur/commit/ef9e23cb8fb80e253f37f30f14d79d54d875d30f

- See https://github.com/termux-user-repository/tur/pull/2115#issuecomment-3650250961

- A different workflow run was successfully detected and reused by each workflow, but the number of the archive is still the same, so this code actually is necessary