### PR TITLE
fix(common-files/building-system-patches/fix-auto-update): TUR support for `build-package-dry-run-simulation.sh`

### DIFF
--- a/common-files/building-system-patches/0002-fix-auto-update.patch
+++ b/common-files/building-system-patches/0002-fix-auto-update.patch
@@ -53,3 +53,16 @@ Do not run check-updated step, which will make it easy to reach GitHub rate limi
  	if [[ -n "${_LATEST_TAGS[${1##*/}]:-}" ]]; then
  		(
  			set +eu
+--- a/scripts/bin/build-package-dry-run-simulation.sh
++++ b/scripts/bin/build-package-dry-run-simulation.sh
+@@ -12,6 +12,10 @@ TERMUX_PACKAGES_DIRECTORIES="
+ packages
+ root-packages
+ x11-packages
++tur
++tur-on-device
++tur-multilib
++tur-hacking
+ "
+ 
+ # Please keep synchronized with the logic of lines 468-547 of 'build-package.sh'.

--- a/tur/rumdl/build.sh
+++ b/tur/rumdl/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Markdown Linter and Formatter written in Rust"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="0.0.203"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/rvben/rumdl/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=eb0e7e196730d576bd62dee0144ebabb3a0eb180c93a65e2b6cba42653fa534f
 TERMUX_PKG_AUTO_UPDATE=true


### PR DESCRIPTION
- Fixes error `build-package-dry-run-simulation.sh: No package rumdl found in any of the enabled repositories. Are you trying to set up a custom repository?` https://github.com/termux-user-repository/tur/actions/runs/20509407196/job/58928561231

- `build-package-dry-run-simulation.sh` cannot read `repo.json` because it is not allowed to run `jq`. This is because `build-package-dry-run-simulation.sh` always runs outside of Docker and may run on a non-GitHub-Actions computer that does not have `jq`.

- This codepath is probably unreachable from the tur-on-device workflow, but that might change or it might somehow be reachable, so include tur-on-device for consistency