### PR TITLE
revbump(tur-on-device/blender5): for `boost` 1.90

### DIFF
--- a/tur-on-device/blender5/build.sh
+++ b/tur-on-device/blender5/build.sh
@@ -4,7 +4,8 @@ TERMUX_PKG_DESCRIPTION="A fully integrated 3D graphics creation suite"
 # https://www.blender.org/about/license/
 TERMUX_PKG_LICENSE="GPL-3.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
-TERMUX_PKG_VERSION=5.0.1
+TERMUX_PKG_VERSION="5.0.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://projects.blender.org/blender/blender
 # Blender does not support 32-bit
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"


### PR DESCRIPTION
- After https://github.com/termux/termux-packages/pull/27925