### PR TITLE
chore(tur-on-device): `TERMUX_PKG_PYTHON_COMMON_DEPS` -> `TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS`

### DIFF
--- a/tur-on-device/blender/build.sh
+++ b/tur-on-device/blender/build.sh
@@ -11,7 +11,7 @@ TERMUX_PKG_SRCURL=git+https://projects.blender.org/blender/blender
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
 TERMUX_PKG_DEPENDS="alembic, boost, brotli, clang, desktop-file-utils, draco, ffmpeg7, fftw, freetype, glew, hicolor-icon-theme, imath, libandroid-execinfo, libandroid-posix-semaphore, libblosc, libc++, libepoxy, libharu, libllvm, libpng, libpugixml, libraw, libsndfile, libspnav, libtbb, libtiff, libwebp, libx11, libxfixes, libxi, libxkbcommon, libyaml-cpp, oidn, openal-soft, opencolorio, openexr, openimageio, openjpeg, openpgl, openshadinglanguage, opensubdiv, openvdb, openxr, potrace, ptex, python, python-numpy, python-pip, shaderc, shared-mime-info, usd, zlib, zstd"
 TERMUX_PKG_BUILD_DEPENDS="boost-headers, git-lfs, mold, sse2neon"
-TERMUX_PKG_PYTHON_COMMON_DEPS="requests"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="requests"
 # do not enable WITH_CYCLES_NATIVE_ONLY - results in crashing when opening the Edit->Preferences->System menu on some devices
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DPYTHON_LIBRARY=$TERMUX_PREFIX/lib/libpython$TERMUX_PYTHON_VERSION.so

--- a/tur-on-device/blender4/build.sh
+++ b/tur-on-device/blender4/build.sh
@@ -11,7 +11,7 @@ TERMUX_PKG_SRCURL=git+https://projects.blender.org/blender/blender
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
 TERMUX_PKG_DEPENDS="alembic, boost, brotli, desktop-file-utils, draco, ffmpeg, fftw, freetype, glew, hicolor-icon-theme, imath, libandroid-execinfo, libandroid-posix-semaphore, libblosc, libc++, libepoxy, libharu, libpng, libpugixml, libraw, libsndfile, libspnav, libtbb, libtiff, libwebp, libx11, libxfixes, libxi, libxkbcommon, libyaml-cpp, oidn, openal-soft, opencolorio, openexr, openimageio, openjpeg, openpgl, openshadinglanguage, opensubdiv, openvdb, openxr, potrace, ptex, python, python-numpy, python-pip, shaderc, shared-mime-info, usd, zlib, zstd"
 TERMUX_PKG_BUILD_DEPENDS="boost-headers, git-lfs, mold, sse2neon"
-TERMUX_PKG_PYTHON_COMMON_DEPS="requests"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="requests"
 # do not enable WITH_CYCLES_NATIVE_ONLY - results in crashing when opening the Edit->Preferences->System menu on some devices
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DPYTHON_LIBRARY=$TERMUX_PREFIX/lib/libpython$TERMUX_PYTHON_VERSION.so

--- a/tur-on-device/blender5/build.sh
+++ b/tur-on-device/blender5/build.sh
@@ -11,7 +11,7 @@ TERMUX_PKG_SRCURL=git+https://projects.blender.org/blender/blender
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"
 TERMUX_PKG_DEPENDS="alembic, boost, brotli, desktop-file-utils, draco, ffmpeg, fftw, freetype, glew, hicolor-icon-theme, imath, libandroid-execinfo, libandroid-posix-semaphore, libblosc, libc++, libepoxy, libharu, libpng, libpugixml, libraw, libsndfile, libspnav, libtbb, libtiff, libwebp, libx11, libxfixes, libxi, libxkbcommon, libyaml-cpp, oidn, openal-soft, opencolorio, openexr, openimageio, openjpeg, openpgl, openshadinglanguage, opensubdiv, openvdb, openxr, potrace, ptex, python, python-numpy, python-pip, shaderc, shared-mime-info, usd, zlib, zstd"
 TERMUX_PKG_BUILD_DEPENDS="boost-headers, git-lfs, mold, sse2neon"
-TERMUX_PKG_PYTHON_COMMON_DEPS="requests"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="requests"
 # do not enable WITH_CYCLES_NATIVE_ONLY - results in crashing when opening the Edit->Preferences->System menu on some devices
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DPYTHON_LIBRARY=$TERMUX_PREFIX/lib/libpython$TERMUX_PYTHON_VERSION.so

--- a/tur-on-device/pyside6/build.sh
+++ b/tur-on-device/pyside6/build.sh
@@ -17,7 +17,7 @@ TERMUX_PKG_DEPENDS="libc++, python, qt6-qtbase, qt6-qtdeclarative, shiboken6"
 TERMUX_PKG_RECOMMENDS="qt6-qtcharts, qt6-qtmultimedia, qt6-qtnetworkauth, qt6-qtscxml, qt6-qtsvg, qt6-qttranslations, qt6-qtwebsockets, qt6-shadertools"
 # error during configure if libllvm and libllvm-static are not both installed
 TERMUX_PKG_BUILD_DEPENDS="libllvm-static, python-numpy, qt6-qtcharts, qt6-qtmultimedia, qt6-qtnetworkauth, qt6-qtscxml, qt6-qtsvg, qt6-qttools, qt6-qtwebsockets, qt6-shadertools"
-TERMUX_PKG_PYTHON_COMMON_DEPS="requests"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="requests"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DCMAKE_SYSTEM_NAME=Linux
 -DNUMPY_INCLUDE_DIR=$TERMUX_PREFIX/lib/python$TERMUX_PYTHON_VERSION/site-packages/numpy/_core/include


### PR DESCRIPTION
- https://github.com/termux/termux-packages/pull/28078 for tur-on-device

- The amount of changes necessary for this in tur-on-device is very minimal, so I do not think it is necessary to rebuild these packages currently.

[no ci]