### PR TITLE
chromium-beta-host-tools: bump to 145.0.7632.18

### DIFF
--- a/tur/chromium-beta-host-tools/build.sh
+++ b/tur/chromium-beta-host-tools/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://www.chromium.org/Home
 TERMUX_PKG_DESCRIPTION="Chromium web browser (Host tools)"
 TERMUX_PKG_LICENSE="BSD 3-Clause"
 TERMUX_PKG_MAINTAINER="@licy183"
-TERMUX_PKG_VERSION=145.0.7632.5
+TERMUX_PKG_VERSION=145.0.7632.18
 TERMUX_PKG_SRCURL=https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$TERMUX_PKG_VERSION-lite.tar.xz
-TERMUX_PKG_SHA256=455eb8c447164e54840b1a1324be0d49a904783b903597635a8785a7f63c1b4a
+TERMUX_PKG_SHA256=5b9395235397a0ae023c14b1e791626c24133677a0b548d629c2c52ee8de5744
 TERMUX_PKG_DEPENDS="atk, cups, dbus, fontconfig, gtk3, krb5, libc++, libevdev, libxkbcommon, libminizip, libnss, libx11, mesa, openssl, pango, pulseaudio, zlib"
 TERMUX_PKG_BUILD_DEPENDS="libffi-static"
 # TODO: Split chromium-common and chromium-headless

--- a/tur/chromium-beta-host-tools/jumbo-patches/0109-content.patch
+++ b/tur/chromium-beta-host-tools/jumbo-patches/0109-content.patch
@@ -2464,11 +2464,11 @@ index 99f590d854..016c264e0e 100644
      if (base::FeatureList::IsEnabled(
 -            features::kCopyFromSurfaceAlwaysCallCallback)) {
 +            ::features::kCopyFromSurfaceAlwaysCallCallback)) {
-       std::move(callback).Run(base::unexpected<std::string>(
-           "Main Host or FrameHost is no longer available."));
+       std::move(callback).Run(base::unexpected<content::CopyFromSurfaceError>(
+           content::CopyFromSurfaceError::kFrameGone));
      }
 @@ -229,7 +229,7 @@ void RenderWidgetHostViewBase::CopyMainAndPopupFromSurface(
-          const viz::CopyOutputBitmapWithMetadata& main_result) {
+          const content::CopyFromSurfaceResult& main_result) {
          if (!popup_frame_host) {
            if (base::FeatureList::IsEnabled(
 -                  features::kCopyFromSurfaceAlwaysCallCallback)) {


### PR DESCRIPTION
Closes #2192