### PR TITLE
revbump(tur-on-device/blender4): for `openshadinglanguage` 1.15.0.0

### DIFF
--- a/tur-on-device/blender4/build.sh
+++ b/tur-on-device/blender4/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_DESCRIPTION="A fully integrated 3D graphics creation suite"
 TERMUX_PKG_LICENSE="GPL-3.0-or-later"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="4.5.6"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=git+https://projects.blender.org/blender/blender
 # Blender does not support 32-bit
 TERMUX_PKG_EXCLUDED_ARCHES="arm, i686"


### PR DESCRIPTION
- For some reason, even though `openshadinglanguage` was bumped to 1.15.0.0 in the same PR as `blender4` was recompiled https://github.com/termux-user-repository/tur/pull/2208 , the build system did not detect `openshadinglanguage` as installed after it was built, so it reinstalled `openshadinglanguage` from the mirror before building `blender4`, so `blender4` was built with the wrong version of `openshadinglanguage`:

```
2026-01-26T06:50:13.0665037Z The following additional packages will be installed:
2026-01-26T06:50:13.0665327Z   openshadinglanguage
2026-01-26T06:50:13.0740010Z The following NEW packages will be installed:
2026-01-26T06:50:13.0740810Z   openshadinglanguage usd
2026-01-26T06:50:13.6978931Z 0 upgraded, 2 newly installed, 0 to remove and 1 not upgraded.
2026-01-26T06:50:13.6979291Z Need to get 26.8 MB of archives.
2026-01-26T06:50:13.6979584Z After this operation, 184 MB of additional disk space will be used.
2026-01-26T06:50:13.6980139Z Get:1 https://tur.kcubeterm.com tur-packages/tur-on-device aarch64 openshadinglanguage aarch64 1.14.8.0 [1414 kB]
2026-01-26T06:50:13.7907126Z Get:2 https://tur.kcubeterm.com tur-packages/tur-on-device aarch64 usd aarch64 25.11-4 [25.4 MB]
2026-01-26T06:50:13.9819027Z Fetched 26.8 MB in 1s (30.7 MB/s)
2026-01-26T06:50:14.0176955Z Selecting previously unselected package openshadinglanguage.
```

it is strange that that happened, but if `blender4` is recompiled again by itself, it should fix the immediate error `CANNOT LINK EXECUTABLE "blender-4.5": library "liboslcomp.so.1.14" not found: needed by main executable`.