### PR TITLE
bump(tur/python-kivy): 2.3.1

### DIFF
--- a/tur/python-kivy/android-as-linux.patch
+++ b/tur/python-kivy/android-as-linux.patch
@@ -1,0 +1,13 @@
+Necessary after Python 3.13 to direct kivy to not attempt to build for use in a non-Termnux app
+
+--- a/setup.py
++++ b/setup.py
+@@ -149,7 +149,7 @@ def check_c_source_compiles(code, include_dirs=None):
+ build_examples = build_examples or \
+     os.environ.get('KIVY_BUILD_EXAMPLES', '0') == '1'
+ 
+-platform = sys.platform
++platform = 'linux'
+ 
+ # Detect Python for android project (http://github.com/kivy/python-for-android)
+ ndkplatform = environ.get('NDKPLATFORM')

--- a/tur/python-kivy/build.sh
+++ b/tur/python-kivy/build.sh
@@ -2,14 +2,12 @@ TERMUX_PKG_HOMEPAGE=https://kivy.org/
 TERMUX_PKG_DESCRIPTION="Open source UI framework written in Python"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
-TERMUX_PKG_VERSION="2.3.0"
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=git+https://github.com/kivy/kivy
-TERMUX_PKG_GIT_BRANCH="$TERMUX_PKG_VERSION"
-TERMUX_PKG_DEPENDS="mesa, mtdev, python, sdl2, sdl2-image, sdl2-mixer, sdl2-ttf, python-pillow, python-pip"
+TERMUX_PKG_VERSION="2.3.1"
+TERMUX_PKG_SRCURL="https://github.com/kivy/kivy/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=83eee956b84ab7bf9e9d5b38544acc40a0e55f05cea7112fd01cda172c98244a
+TERMUX_PKG_DEPENDS="mtdev, opengl, python, python-pillow, python-pip, sdl2, sdl2-image, sdl2-mixer, sdl2-ttf"
 TERMUX_PKG_BUILD_DEPENDS="xorgproto"
-TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="'Cython==0.29.37', wheel"
-TERMUX_PKG_PYTHON_CROSS_BUILD_DEPS="${TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS}, packaging"
+TERMUX_PKG_PYTHON_COMMON_BUILD_DEPS="'Cython==3.0.11', wheel, packaging"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_RM_AFTER_INSTALL="
 bin/
@@ -20,10 +18,10 @@ termux_step_pre_configure() {
 	CFLAGS+=" -Wno-incompatible-function-pointer-types"
 
 	LDFLAGS+=" -lpython${TERMUX_PYTHON_VERSION}"
-	export KIVY_SDL2_PATH=$TERMUX_PREFIX/include/SDL2
+	export KIVY_SDL2_PATH="$TERMUX_PREFIX/include/SDL2"
 }
 
 termux_step_make_install() {
-	export PYTHONPATH=$TERMUX_PREFIX/lib/python${TERMUX_PYTHON_VERSION}/site-packages
-	pip install --no-deps . --prefix $TERMUX_PREFIX
+	export PYTHONPATH="$TERMUX_PREFIX/lib/python${TERMUX_PYTHON_VERSION}/site-packages"
+	pip install --no-deps . --prefix "$TERMUX_PREFIX"
 }


### PR DESCRIPTION
- Fix build with Python 3.13 using `android-as-linux.patch`

- bump Cython version to exactly 3.0.11 to avoid a variety of multiple errors due to it being too old or too new; the window of Cython versions working to build `python-kivy` may be narrowing and this might become a more severe problem in the future. This issue helped: https://github.com/jswhit/pygrib/issues/238