### PR TITLE
fix(tur/python-kivy): intervene in detection of `sys.platform` at runtime as well as build-time

### DIFF
--- a/tur/python-kivy/android-as-linux.patch
+++ b/tur/python-kivy/android-as-linux.patch
@@ -11,3 +11,14 @@ Necessary after Python 3.13 to direct kivy to not attempt to build for use in a 
  
  # Detect Python for android project (http://github.com/kivy/python-for-android)
  ndkplatform = environ.get('NDKPLATFORM')
+--- a/kivy/utils.py
++++ b/kivy/utils.py
+@@ -444,7 +444,7 @@ def _get_platform():
+         return 'win'
+     elif _sys_platform == 'darwin':
+         return 'macosx'
+-    elif _sys_platform.startswith('linux'):
++    elif _sys_platform.startswith('linux') or _sys_platform.startswith('android'):
+         return 'linux'
+     elif _sys_platform.startswith('freebsd'):
+         return 'linux'

--- a/tur/python-kivy/build.sh
+++ b/tur/python-kivy/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Open source UI framework written in Python"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="2.3.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://github.com/kivy/kivy/archive/refs/tags/$TERMUX_PKG_VERSION.tar.gz"
 TERMUX_PKG_SHA256=83eee956b84ab7bf9e9d5b38544acc40a0e55f05cea7112fd01cda172c98244a
 TERMUX_PKG_DEPENDS="mtdev, opengl, python, python-pillow, python-pip, sdl2, sdl2-image, sdl2-mixer, sdl2-ttf"


### PR DESCRIPTION
- This is necessary in order to run this software in Termux which depends on `python-kivy`, using `python Launcher.py` https://github.com/ArchipelagoMW/Archipelago