### PR TITLE
bump(tur/python3.11): 3.11.15

### DIFF
--- a/tur/python3.11/build.sh
+++ b/tur/python3.11/build.sh
@@ -4,9 +4,9 @@ TERMUX_PKG_DESCRIPTION="Python programming language intended to enable clear pro
 TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_LICENSE_FILE="LICENSE"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
-TERMUX_PKG_VERSION=3.11.10
+TERMUX_PKG_VERSION=3.11.15
 TERMUX_PKG_SRCURL=https://www.python.org/ftp/python/${TERMUX_PKG_VERSION}/Python-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=07a4356e912900e61a15cb0949a06c4a05012e213ecd6b4e84d0f67aabbee372
+TERMUX_PKG_SHA256=272179ddd9a2e41a0fc8e42e33dfbdca0b3711aa5abf372d3f2d51543d09b625
 TERMUX_PKG_AUTO_UPDATE=false
 TERMUX_PKG_DEPENDS="gdbm, libandroid-posix-semaphore, libandroid-support, libbz2, libcrypt, libexpat, libffi, liblzma, libsqlite, ncurses, ncurses-ui-libs, openssl, readline, zlib"
 TERMUX_PKG_BUILD_DEPENDS="tk"
@@ -77,8 +77,8 @@ termux_step_pre_configure() {
 	# gcc for include paths when finding headers for determining
 	# if extension modules should be built (specifically, the
 	# zlib extension module is not built without this):
-	CPPFLAGS+=" -I$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/include"
-	LDFLAGS+=" -L$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib"
+	CPPFLAGS+=" -isystem$TERMUX_PREFIX/include -isystem$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/include"
+	LDFLAGS+=" -L$TERMUX_PREFIX/lib -L$TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/lib"
 	if [ $TERMUX_ARCH = x86_64 ]; then LDFLAGS+=64; fi
 
 	if [ "$TERMUX_ON_DEVICE_BUILD" = "true" ]; then

--- a/tur/python3.11/build.sh
+++ b/tur/python3.11/build.sh
@@ -88,6 +88,9 @@ termux_step_pre_configure() {
 		CPPFLAGS+=" -D__ANDROID_API__=$(getprop ro.build.version.sdk)"
 	else
 		TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-build-python=python$_MAJOR_VERSION"
+		# https://github.com/termux-user-repository/tur/pull/2442#issuecomment-4945448006
+		export CPPFLAGS="-I$TERMUX_PREFIX/include $CPPFLAGS"
+		export LDFLAGS="-L$TERMUX_PREFIX/lib $LDFLAGS"
 	fi
 
 	export LIBCRYPT_LIBS="-lcrypt"


### PR DESCRIPTION
bump(tur/python3.11): 3.11.15

- Updated Python from 3.11.10 → 3.11.15
- Updated source URL and SHA256 checksum
- Rebased all existing TUR patches against upstream 3.11.15
- Verified clean patch application with no rejects

Build fixes:
- Added PKG_CONFIG_PATH="${TERMUX_PREFIX}/lib/pkgconfig"
- Added TERMUX_PREFIX include/lib paths to CPPFLAGS and LDFLAGS

Reason:
- Without these adjustments, configure phase fails to properly detect
  Termux-provided libraries (libffi, openssl, sqlite, etc.)
- This results in missing or broken modules

Observed failures without flags:
- _bz2
- _crypt
- _curses
- _curses_panel
- _dbm
- _elementtree
- _gdbm
- pyexpat
- readline

Validation:
- CI build passes successfully:
  https://github.com/plfj/tur/actions/runs/24635240066
- Local build tested
- Verified working:
  - multiprocessing (including shared memory)
  - pip install
  - standard library modules

CI comparison:
- Without flags: multiple core modules fail to build (see above)
- With flags: full build succeeds

No regressions observed compared to 3.11.10.

Notes:
- Changes are minimal and limited to ensuring correct dependency
  resolution in the Termux environment
- No functional changes to upstream Python behavior