### PR TITLE
addpkg(tur/solana): Solana & Other Cli tool

### DIFF
--- a/tur/solana/build.sh
+++ b/tur/solana/build.sh
@@ -1,0 +1,92 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/anza-xyz/agave
+TERMUX_PKG_DESCRIPTION="Solana CLI binaries package provides the essential tools to interact with the Solana blockchain, including solana-cli, spl-token, agave-validator etc."
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="3.1.14"
+TERMUX_PKG_SRCURL="https://github.com/anza-xyz/agave/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=b7e84caad554388a04e64c40f535b787fea3d1d24ead1ced4748294e8ed0214d
+TERMUX_PKG_DEPENDS="libandroid-shmem, openssl, protobuf, zlib"
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXCLUDED_ARCHES="i686, arm"
+
+termux_step_pre_configure() {
+	termux_setup_protobuf
+	termux_setup_rust
+
+	export PROTOC="$(command -v protoc)"
+	export LDFLAGS+=" -landroid-shmem"
+
+	# SYMLINK libclang.so.1 to libclang.so
+	# without libclang.so `clang-sys` throws error
+	local _libclang="$(find /usr/lib -name 'libclang-*.so.1' | sort -V | tail -1)"
+
+	mkdir -p "$TERMUX_PKG_TMPDIR/libclang-tmp"
+	ln -sf "$_libclang" "$TERMUX_PKG_TMPDIR/libclang-tmp/libclang.so"
+	export LIBCLANG_PATH="$TERMUX_PKG_TMPDIR/libclang-tmp"
+
+	cargo vendor
+	find ./vendor \
+		-mindepth 1 -maxdepth 1 -type d \
+		! -wholename ./vendor/protobuf-src \
+		! -wholename ./vendor/rustls-platform-verifier \
+		-exec rm -rf '{}' \;
+
+	find vendor/rustls-platform-verifier -type f -print0 |
+		xargs -0 sed -i \
+			-e 's|"android"|"disabling_this_because_it_is_for_building_an_apk"|g' \
+			-e "s|ANDROID|DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK|g" \
+			-e 's|"linux"|"android"|g'
+
+	# use installed protoc & skip compiling protobuf-src
+	local protobuf_patch="$TERMUX_PKG_BUILDER_DIR/point-to-host-protoc.diff"
+	patch -p1 -d ./vendor/protobuf-src <"$protobuf_patch"
+
+	# disable hidapi features
+	sed -i 's/default = \["linux-static-hidraw"\]/default = []/' remote-wallet/Cargo.toml
+	sed -i '/\[patch.crates-io\]/a protobuf-src = { path = "./vendor/protobuf-src" }' Cargo.toml
+	sed -i '/\[patch.crates-io\]/a sys-info = { git = "https://github.com/FillZpp/sys-info-rs", rev = "refs/pull/118/head" }' Cargo.toml
+	sed -i '/\[patch.crates-io\]/a rustls-platform-verifier = { path = "./vendor/rustls-platform-verifier" }' Cargo.toml
+}
+
+termux_step_make() {
+	# We use -p (package) instead of --bin to ensure we only build
+	# the specific workspace members, which helps skip heavy validator code.
+	cargo build \
+		--target "${CARGO_TARGET_NAME}" \
+		--release \
+		--no-default-features \
+		-p solana-cli \
+		-p solana-keygen \
+		-p agave-validator \
+		-p solana-faucet \
+		-p solana-stake-accounts \
+		-p solana-tokens \
+		-p solana-test-validator
+}
+
+termux_step_make_install() {
+	# This will look for all compiled binaries in the release folder and install them
+	local bin_dir="target/${CARGO_TARGET_NAME}/release"
+	if [[ ! -d "$bin_dir" ]]; then
+		bin_dir="target/release"
+	fi
+
+	local binaries=(
+		"solana"
+		"solana-keygen"
+		"agave-validator"
+		"solana-faucet"
+		"solana-stake-accounts"
+		"solana-tokens"
+		"solana-test-validator"
+	)
+
+	for binary in "${binaries[@]}"; do
+		if [[ -f "${bin_dir}/$binary" ]]; then
+			install -Dm755 "${bin_dir}/$binary" "$TERMUX_PREFIX/bin/$binary"
+		else
+			echo "Warning: Binary $binary not found in $bin_dir, skipping."
+		fi
+	done
+}

--- a/tur/solana/point-to-host-protoc.diff
+++ b/tur/solana/point-to-host-protoc.diff
@@ -1,0 +1,45 @@
+--- a/build.rs	2022-09-03 02:43:27.000000000 +0600
++++ b/build.rs	2026-05-15 16:44:25.165720358 +0600
+@@ -18,21 +18,28 @@
+ use std::fs;
+ use std::path::PathBuf;
+
+-fn main() -> Result<(), Box<dyn Error>> {
+-    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+-    let install_dir = out_dir.join("install");
+-    fs::create_dir_all(&install_dir)?;
++// Termux cross-compilation shim for protobuf-src.
++// Instead of compiling libprotobuf from C++ (which fails because Cargo
++// sets CC/CXX for the Android target, not the build host), we reuse the
++// protoc binary that Termux's own `protobuf` package provides.
++fn main() {
++    let protoc = std::env::var("PROTOC")
++        .expect("PROTOC must be set; install the `protobuf` Termux package");
+
+-    autotools::Config::new("protobuf")
+-        .disable("maintainer-mode", None)
+-        .out_dir(&install_dir)
+-        .build();
+-
+-    // Move the build directory out of the installation directory.
+-    let _ = fs::remove_dir_all(out_dir.join("build"));
+-    fs::rename(install_dir.join("build"), out_dir.join("build"))?;
++    // Derive the installation prefix from the path to protoc:
++    //   e.g. /data/data/com.termux/files/usr/bin/protoc
++    //        -> /data/data/com.termux/files/usr
++    let install_dir = std::path::Path::new(&protoc)
++        .parent()          // …/bin
++        .and_then(|p| p.parent()) // …/usr  (the prefix)
++        .expect("Could not determine install prefix from PROTOC path")
++        .to_path_buf();
+
++    // INSTALL_DIR is read at compile-time by protobuf_src::protoc() and
++    // protobuf_src::include() via env!("INSTALL_DIR").
+     println!("cargo:rustc-env=INSTALL_DIR={}", install_dir.display());
++    // Required by crates that consume DEP_PROTOBUF_SRC_CXXBRIDGE_DIR0.
+     println!("cargo:CXXBRIDGE_DIR0={}/include", install_dir.display());
+-    Ok(())
++    // Required by crates that consume DEP_PROTOBUF_SRC_ROOT.
++    println!("cargo:ROOT={}", install_dir.display());
+ }
+


### PR DESCRIPTION
## Add Solana package for Termux

**This PR adds packaging support for solana v3.1.14 for Termux.**

Agave/Solana is a high-performance blockchain platform and developer ecosystem providing command-line tools, validator software, local testing utilities, wallet/key management, and token management tools for the Solana network.

The package successfully builds and runs on "aarch64" Android/Termux environments.

### Included binaries

- [x] `solana` — Main Solana CLI utility
- [x] `solana-keygen` — Keypair generation and wallet management tool
- [x] `agave-validator` — Solana validator node binary
- [x] `solana-faucet` — Local testnet faucet service
- [x] `solana-stake-accounts` — Stake account inspection utility
- [x] `solana-tokens` — SPL token management CLI
- [x] `solana-test-validator` — Local development validator for testing

Notes
-----------

- **Solana currently supports only 64-bit architectures (`aarch64`, `x86_64`).**
- Solana's virtual machine (sBPF) operates entirely on 64-bit registers and pointers. 

- [x] Build tested successfully inside Termux 