### PR TITLE
fix(tur/playit): fix all immediately obvious problems

### DIFF
--- a/tur/playit/build.sh
+++ b/tur/playit/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="playit is a global proxy that allows anyone to host a se
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_MAINTAINER="@nisheri-ascar"
 TERMUX_PKG_VERSION="1.0.5"
+TERMUX_PKG_REVISION=1
 _REAL_VERSION="${TERMUX_PKG_VERSION/\~/-}"
 TERMUX_PKG_SRCURL=https://github.com/playit-cloud/playit-agent/archive/v${_REAL_VERSION}.tar.gz
 TERMUX_PKG_SHA256=c2e7c8252425c2f04e5cba2bc209b48d12675740df0448bb03022ca3d3168fa4
@@ -11,12 +12,24 @@ TERMUX_PKG_AUTO_UPDATE=true
 
 termux_step_pre_configure() {
 	termux_setup_rust
+
+	find . -type f -print0 | \
+		xargs -0 sed -i \
+		-e 's|"android"|"disabling_this_because_it_is_for_building_an_apk"|g' \
+		-e 's|"linux"|"android"|g'
 }
 
 termux_step_make() {
-	cargo build --jobs $TERMUX_PKG_MAKE_PROCESSES --target $CARGO_TARGET_NAME --release
+	cargo build \
+		--jobs "$TERMUX_PKG_MAKE_PROCESSES" \
+		--target "$CARGO_TARGET_NAME" \
+		--release \
+		--all-features
 }
 
 termux_step_make_install() {
-	install -Dm755 -t $TERMUX_PREFIX/bin target/${CARGO_TARGET_NAME}/release/playit-cli
+	install -Dm755 -t "$TERMUX_PREFIX/bin" "target/${CARGO_TARGET_NAME}/release/playitd"
+	install -Dm755 -t "$TERMUX_PREFIX/bin" "target/${CARGO_TARGET_NAME}/release/playitd-service"
+	install -Dm755 -t "$TERMUX_PREFIX/bin" "target/${CARGO_TARGET_NAME}/release/playitd-tray"
+	install -Dm755 -t "$TERMUX_PREFIX/bin" "target/${CARGO_TARGET_NAME}/release/playit-cli"
 }

--- a/tur/playit/run-path.patch
+++ b/tur/playit/run-path.patch
@@ -1,0 +1,20 @@
+--- a/packages/playit-ipc/src/paths.rs
++++ b/packages/playit-ipc/src/paths.rs
+@@ -11,7 +11,7 @@ pub fn playit_config_dir() -> PathBuf {
+ pub fn default_socket_path_string() -> String {
+     #[cfg(target_os = "linux")]
+     {
+-        "/var/run/playitd.sock".to_string()
++        "@TERMUX_PREFIX@/var/run/playitd.sock".to_string()
+     }
+ 
+     #[cfg(target_os = "macos")]
+@@ -33,7 +33,7 @@ pub fn default_socket_path_string() -> String {
+ pub(crate) fn default_socket_path_static() -> &'static str {
+     #[cfg(target_os = "linux")]
+     {
+-        "/var/run/playitd.sock"
++        "@TERMUX_PREFIX@/var/run/playitd.sock"
+     }
+ 
+     #[cfg(target_os = "macos")]


### PR DESCRIPTION
- Fixes https://github.com/termux-user-repository/tur/issues/2494

- Provide all possibly-needed binaries, `playit-cli`, `playitd`, `playitd-service` and `playitd-tray`

- Prepend `@TERMUX_PREFIX@` to `/var` path

- Treat Android as Linux

- Launch seems to work using these commands:

```
playitd --secret-path $PREFIX/etc/playit/playit.toml -l $PREFIX/var/log/playit/playit.log &
playit-cli
```