### PR TITLE
bada: New package

### DIFF
--- a/bada/build.sh
+++ b/bada/build.sh
@@ -1,0 +1,34 @@
+TERMUX_PKG_HOMEPAGE="https://github.com/Natarizki/bada-lang"
+TERMUX_PKG_DESCRIPTION="Bada programming language compiler - hybrid C/Rust-style language with LLVM backend"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_LICENSE_FILE="LICENSE"
+TERMUX_PKG_MAINTAINER="@Natarizki"
+TERMUX_PKG_VERSION="1.2.0"
+TERMUX_PKG_SRCURL="https://github.com/Natarizki/bada-lang/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256="4974361fae81873bd592f1c2c4b84882249187684d4c0b4fbe982c354c71da20"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="llvm"
+TERMUX_PKG_BUILD_DEPENDS="llvm, clang, cmake, ninja"
+
+termux_step_make() {
+	cmake \
+		-G Ninja \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX="${TERMUX_PREFIX}" \
+		-DCMAKE_CXX_COMPILER="${CXX}" \
+		-DLLVM_DIR="$(${TERMUX_PREFIX}/bin/llvm-config --cmakedir 2>/dev/null || echo '')" \
+		-B "${TERMUX_PKG_BUILDER_DIR}/build" \
+		"${TERMUX_PKG_SRCDIR}"
+	ninja -C "${TERMUX_PKG_BUILDER_DIR}/build"
+}
+
+termux_step_make_install() {
+	install -Dm755 \
+		"${TERMUX_PKG_BUILDER_DIR}/build/bada" \
+		"${TERMUX_PREFIX}/bin/bada"
+
+	install -d "${TERMUX_PREFIX}/share/doc/bada"
+	install -Dm644 \
+		"${TERMUX_PKG_SRCDIR}/README.md" \
+		"${TERMUX_PREFIX}/share/doc/bada/README.md"
+}

--- a/tur/glyph/build.sh
+++ b/tur/glyph/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/Natarizki/glyph
+TERMUX_PKG_DESCRIPTION="Pure C ASCII art generator with custom fonts, true color styles, and image-to-ASCII conversion"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="@Natarizki"
+TERMUX_PKG_VERSION="1.0.0"
+TERMUX_PKG_SRCURL=https://github.com/Natarizki/glyph/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=85134fce77e16fecc204852070fd8004a066bf04fcab1d38e77ec7327f62f8a0
+TERMUX_PKG_DEPENDS=""
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make_install() {
+	make install PREFIX=$TERMUX_PREFIX
+}


### PR DESCRIPTION
Bada-Lang: hybrid C/Rust-style programming language compiler with LLVM backend.

Compiles to native ARM64 binaries via LLVM IR, with full C/C++ interoperability
through an integrated C++ transpiler mode. Supports inline assembly, structs,
enums, pattern matching, closures, module imports, and a custom standard library.

Homepage: https://github.com/Natarizki/bada-lang
License: Apache-2.0