### PR TITLE
glyph: new package

### DIFF
--- a/tur/glyph/build.sh
+++ b/tur/glyph/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/Natarizki/glyph
+TERMUX_PKG_DESCRIPTION="Pure C ASCII art generator with custom fonts, true color styles, and image-to-ASCII conversion"
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_MAINTAINER="Natarizki <natakeren890@gmail.com>"
+TERMUX_PKG_VERSION="1.0.0"
+TERMUX_PKG_SRCURL=https://github.com/Natarizki/glyph/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=85134fce77e16fecc204852070fd8004a066bf04fcab1d38e77ec7327f62f8a0
+TERMUX_PKG_DEPENDS=""
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make_install() {
+	make install PREFIX=$TERMUX_PREFIX
+}

--- a/tur/glyph/build.sh
+++ b/tur/glyph/build.sh
@@ -5,7 +5,7 @@ TERMUX_PKG_MAINTAINER="Natarizki <natakeren890@gmail.com>"
 TERMUX_PKG_VERSION="1.0.0"
 TERMUX_PKG_SRCURL=https://github.com/Natarizki/glyph/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=85134fce77e16fecc204852070fd8004a066bf04fcab1d38e77ec7327f62f8a0
-TERMUX_PKG_DEPENDS=""
+# TERMUX_PKG_DEPENDS=""
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_make_install() {


### PR DESCRIPTION
## Description

Adds `glyph` — a pure C, zero-dependency ASCII art generator for the terminal.

### Features
- Custom font format (`.nfont`) with full FIGlet (`.flf`) support
- 24-bit true color styles: plain, gradient, rainbow, gay, border
- Image-to-ASCII conversion (PNG/JPG) via bundled stb_image
- UTF-8 safe rendering
- Zero external dependencies (pure C + libc only)
- Auto-resolves fonts from local, user, and system FIGlet font directories

### Links
- Source: https://github.com/Natarizki/glyph
- License: Apache-2.0
- Release: https://github.com/Natarizki/glyph/releases/tag/v1.0.0

### Build tested
- [x] Builds successfully via `make install`
- [x] CI verified on Linux (x86_64, ARM64), macOS, and Windows via GitHub Actions

## Checklist
- [x] I have read the contribution guidelines
- [x] `build.sh` follows the sample template format
- [x] Package builds and installs correctly