### PR TITLE
ctags: disable libxml

### DIFF
--- a/tur/ctags-cross/build.sh
+++ b/tur/ctags-cross/build.sh
@@ -3,11 +3,11 @@ TERMUX_PKG_DESCRIPTION="Universal ctags: Source code index builder"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="2:6.1.0"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/universal-ctags/ctags/archive/refs/tags/v${TERMUX_PKG_VERSION:2}.tar.gz
 TERMUX_PKG_SHA256=1eb6d46d4c4cace62d230e7700033b8db9ad3d654f2d4564e87f517d4b652a53
-TERMUX_PKG_BUILD_DEPENDS="libiconv, libjansson, libxml2, libyaml"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-tmpdir=$TERMUX_PREFIX/tmp --disable-static"
+TERMUX_PKG_BUILD_DEPENDS="libiconv, libjansson, libyaml"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--enable-tmpdir=$TERMUX_PREFIX/tmp --disable-static --disable-xml"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_HOSTBUILD=true
 


### PR DESCRIPTION
I am getting this when building ctags:
ctags: error while loading shared libraries: libxml2.so.2: cannot open shared object file: No such file or directory

With this change everything works.
I suspect the deps are set wrongly, and are using the target libxml2. Host's libxml2 was probably installed during container setup, but not any more.

Fixes #2599