### PR TITLE
fix(tur-on-device/shiboken6): mark as `TERMUX_SUBPKG_DEPEND_ON_PARENT=false`

### DIFF
--- a/tur-on-device/pyside6/build.sh
+++ b/tur-on-device/pyside6/build.sh
@@ -8,6 +8,7 @@ LICENSES/Qt-GPL-exception-1.0.txt
 "
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="6.11.1"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL="https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-$TERMUX_PKG_VERSION-src/pyside-setup-everywhere-src-$TERMUX_PKG_VERSION.tar.xz"
 TERMUX_PKG_SHA256=6ffd9835bb0dd2c56f061d62f1616bb1707cfc0202b80e3165d6be087f3965e2
 TERMUX_PKG_AUTO_UPDATE=true

--- a/tur-on-device/pyside6/shiboken6.subpackage.sh
+++ b/tur-on-device/pyside6/shiboken6.subpackage.sh
@@ -1,5 +1,6 @@
 TERMUX_SUBPKG_DESCRIPTION="Generates bindings for C++ using CPython source code"
 TERMUX_PKG_DEPENDS="clang, qt6-qtbase, libxml2, libxslt"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
 TERMUX_SUBPKG_INCLUDE="
 */*hiboken*
 */*/*hiboken*


### PR DESCRIPTION
- Fixes https://github.com/termux-user-repository/tur/issues/2607

- Necessary in order for the dependency on `shiboken6` of `pyside6` to take effect