### PR TITLE
ci: switch back from staging termux-packages to normal after Python 3.14

### DIFF
--- a/.github/workflows/package_on_device.yml
+++ b/.github/workflows/package_on_device.yml
@@ -273,11 +273,7 @@ jobs:
       env:
         ARCH: ${{ matrix.target_arch }}
       run: |
-        ./common-files/build-termux-docker.sh login -c "ln -sf \${PREFIX}/etc/termux/mirrors/default \${PREFIX}/etc/termux/chosen_mirrors"
-        ./common-files/build-termux-docker.sh login -c "sed -i 's/stable/staging/g' \${PREFIX}/etc/apt/sources.list"
         ./common-files/build-termux-docker.sh login ./scripts/setup-termux.sh
-        ./common-files/build-termux-docker.sh login -c "sed -i 's/stable/staging/g' \${PREFIX}/etc/apt/sources.list"
-        ./common-files/build-termux-docker.sh login -c "apt update"
         declare -a packages=()
         for repo_path in $(jq --raw-output 'del(.pkg_format) | keys | .[]' repo.json); do
           repo=$(jq --raw-output '.["'${repo_path}'"].name' repo.json)

--- a/repo.json
+++ b/repo.json
@@ -2,7 +2,7 @@
   "pkg_format": "debian",
   "packages": {
     "name": "termux-main",
-    "distribution": "staging",
+    "distribution": "stable",
     "component": "main",
     "url": "https://packages-cf.termux.dev/apt/termux-main"
   },
@@ -38,13 +38,13 @@
   },
   "root-packages": {
     "name": "termux-root",
-    "distribution": "staging",
+    "distribution": "root",
     "component": "stable",
     "url": "https://packages-cf.termux.dev/apt/termux-root"
   },
   "x11-packages": {
     "name": "termux-x11",
-    "distribution": "staging",
+    "distribution": "x11",
     "component": "main",
     "url": "https://packages-cf.termux.dev/apt/termux-x11"
   }


### PR DESCRIPTION
- After https://github.com/termux-user-repository/tur/pull/2615

- After https://github.com/termux-user-repository/tur/pull/2616