### PR TITLE
addpkg(tur/coded): 0.1.1

### DIFF
--- a/tur/coded/build.sh
+++ b/tur/coded/build.sh
@@ -1,0 +1,26 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/HashShin/coded
+TERMUX_PKG_DESCRIPTION="A mobile-first code editor that runs in your browser"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@HashShin"
+TERMUX_PKG_VERSION="0.1.1"
+TERMUX_PKG_SRCURL="https://github.com/HashShin/coded/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=0123375865e6ae49d21a75ba535ccfe32bf767df3314ff60f71cc68dec02c5bc
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_AUTO_UPDATE=true
+
+termux_step_pre_configure() {
+	termux_setup_golang
+}
+
+termux_step_make() {
+	go build \
+		-trimpath \
+		-ldflags="-s -w" \
+		-o coded \
+		.
+}
+
+termux_step_make_install() {
+	install -Dm755 coded \
+		"${TERMUX_PREFIX}/bin/coded"
+}


### PR DESCRIPTION
Add Coded, a mobile-first browser code editor designed to work well in Termux.

Upstream: https://github.com/HashShin/coded
License: MIT