### PR TITLE
revbump(tur/bazel8): move to standalone package

### DIFF
--- a/tur/bazel/bazel8.subpackage.sh
+++ b/tur/bazel/bazel8.subpackage.sh
@@ -1,5 +1,0 @@
-TERMUX_SUBPKG_DESCRIPTION="Correct, reproducible, and fast builds for everyone (Version 8)"
-TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
-TERMUX_SUBPKG_INCLUDE="
-bin/bazel-$TERMUX_PKG_VERSION
-"

--- a/tur/bazel8/0001-strerror_r.patch
+++ b/tur/bazel8/0001-strerror_r.patch
@@ -1,0 +1,13 @@
+Bionic libc's `strerror_r` returns `char *`, which is the same as GNU libc.
+
+--- a/src/main/native/unix_jni_linux.cc
++++ b/src/main/native/unix_jni_linux.cc
+@@ -31,7 +31,7 @@
+   // functionality which is not compatible with not the
+   // SUSv3-conformant one which returns an error code; see DESCRIPTION
+ // at strerror(3).
+-#if !__GLIBC__ || (_POSIX_C_SOURCE >= 200112L && !_GNU_SOURCE)
++#if (!__GLIBC__ && !defined(__ANDROID__)) || (_POSIX_C_SOURCE >= 200112L && !_GNU_SOURCE)
+   if (strerror_r(error_number, buf, sizeof buf) == -1) {
+     return std::string("");
+   } else {

--- a/tur/bazel8/0002-impl-wait3.patch
+++ b/tur/bazel8/0002-impl-wait3.patch
@@ -1,0 +1,14 @@
+--- a/src/main/tools/process-tools.cc
++++ b/src/main/tools/process-tools.cc
+@@ -217,7 +217,11 @@
+     // Discard any zombies that we may get when the child subreaper feature is
+     // enabled.
+     do {
++#ifndef __ANDROID__
+       err = wait3(&status, 0, rusage);
++#else
++      err = wait4(-1, &status, 0, rusage);
++#endif
+     } while (err != pid || (err == -1 && errno == EINTR));
+   } else {
+     do {

--- a/tur/bazel8/0003-disable-sandbox.patch
+++ b/tur/bazel8/0003-disable-sandbox.patch
@@ -1,0 +1,12 @@
+`sandbox` will not work on Android due to SELinux rules
+
+--- a/src/main/tools/BUILD
++++ b/src/main/tools/BUILD
+@@ -75,6 +75,7 @@
+         "//src/conditions:freebsd": ["dummy-sandbox.c"],
+         "//src/conditions:openbsd": ["dummy-sandbox.c"],
+         "//src/conditions:windows": ["dummy-sandbox.c"],
++        "//src/conditions:linux": ["dummy-sandbox.c"],
+         "//conditions:default": [
+             "linux-sandbox.cc",
+             "linux-sandbox.h",

--- a/tur/bazel8/0004-spawn.patch
+++ b/tur/bazel8/0004-spawn.patch
@@ -1,0 +1,10 @@
+--- a/src/main/cpp/BUILD
++++ b/src/main/cpp/BUILD
+@@ -54,6 +54,7 @@
+         "//src/conditions:windows": WIN_LINK_OPTS,
+         "//conditions:default": [
+             "-lrt",
++            "-l:libandroid-spawn.a",
+         ],
+     }),
+     deps = [

--- a/tur/bazel8/0005-bazelrc-path.patch
+++ b/tur/bazel8/0005-bazelrc-path.patch
@@ -1,0 +1,11 @@
+--- a/src/main/cpp/BUILD
++++ b/src/main/cpp/BUILD
+@@ -178,7 +161,7 @@
+         # For posix platforms, this can include environment variables in the
+         # form ${var_name}. Braces are required.
+         "//conditions:default": [
+-            "-DBAZEL_SYSTEM_BAZELRC_PATH=\\\"/etc/bazel.bazelrc\\\"",
++            "-DBAZEL_SYSTEM_BAZELRC_PATH=\\\"@TERMUX_PREFIX@/etc/bazel.bazelrc\\\"",
+         ],
+     }),
+     visibility = [

--- a/tur/bazel8/0006-force-use-external-patch_tools.patch
+++ b/tur/bazel8/0006-force-use-external-patch_tools.patch
@@ -1,0 +1,14 @@
+Don't know why `grpc.patch` cannot be patched with builtin_patch_tool of bazel.
+No matter what, force using the external patch_tool.
+
+--- a/tools/build_defs/repo/utils.bzl
++++ b/tools/build_defs/repo/utils.bzl
+@@ -144,7 +144,7 @@
+         patch_tool = ctx.attr.patch_tool
+     if not patch_tool:
+         patch_tool = "patch"
+-        native_patch = True
++        native_patch = False
+     else:
+         native_patch = False
+ 

--- a/tur/bazel8/0007-import-termux-patches.patch
+++ b/tur/bazel8/0007-import-termux-patches.patch
@@ -1,0 +1,77 @@
+--- a/third_party/BUILD
++++ b/third_party/BUILD
+@@ -35,6 +35,7 @@
+         "//third_party/py/mock:srcs",
+         "//third_party/py/six:srcs",
+         "//third_party/remoteapis:srcs",
++        "//third_party/termux-patches:srcs",
+     ],
+ )
+ 
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -418,3 +418,64 @@
+ register_toolchains("//src/main/res:empty_rc_toolchain")
+ 
+ register_toolchains("@graalvm_toolchains//:gvm")
++
++# =========================================
++# Termux patches
++# =========================================
++
++single_version_override(
++    module_name = "abseil-cpp",
++    patch_strip = 1,
++    patches = [
++       "//third_party/termux-patches:z-absl.patch",
++    ],
++    patch_cmds = [
++        "patch -p1 -i termux-patches/absl.patch",
++    ]
++)
++
++single_version_override(
++    module_name = "c-ares",
++    patch_strip = 1,
++    patches = [
++       "//third_party/termux-patches:z-cares.patch",
++       "//third_party/termux-patches:z-cares-config.patch",
++    ],
++    patch_cmds = [
++        "patch -p1 -i termux-patches/cares.patch",
++        "patch -p1 -i termux-patches/cares-config.patch",
++    ]
++)
++
++single_version_override(
++    module_name = "grpc",
++    patch_strip = 1,
++    patches = [
++        "//third_party/termux-patches:z-grpc.patch",
++    ],
++    patch_cmds = [
++        "patch -p1 -i termux-patches/grpc.patch",
++    ]
++)
++
++single_version_override(
++    module_name = "protobuf",
++    patch_strip = 1,
++    patches = [
++       "//third_party/termux-patches:z-protobuf.patch",
++    ],
++    patch_cmds = [
++        "patch -p1 -i termux-patches/protobuf.patch",
++    ]
++)
++
++single_version_override(
++    module_name = "rules_cc",
++    patch_strip = 1,
++    patches = [
++        "//third_party/termux-patches:z-rules_cc.patch"
++    ],
++    patch_cmds = [
++        "patch -p1 -i termux-patches/rules_cc.patch",
++    ]
++)

--- a/tur/bazel8/0008-run-elf-cleaner-for-bundled-tools.patch
+++ b/tur/bazel8/0008-run-elf-cleaner-for-bundled-tools.patch
@@ -1,0 +1,239 @@
+For a `cc_binary` target that will be packaged, replace its name (`@ORIGIN_NAME@`)
+with `@ORIGIN_NAME@_orig`, and add the following target after it.
+
+```
+genrule(
+    name = "@ORIGIN_NAME@_cleaner",
+    srcs = [
+        ":@ORIGIN_NAME@_orig",
+    ],
+    outs = ["@ORIGIN_NAME@"],
+    cmd = "\n".join([
+        "TEMP_FILE=\"$$(mktemp -t bazel.XXXXXXXX)\"",
+        "cp \"$(location :@ORIGIN_NAME@_orig)\" \"$${TEMP_FILE}\"",
+        "termux-elf-cleaner --api-level=24 \"$${TEMP_FILE}\"",
+        "cp \"$${TEMP_FILE}\" \"$@\"",
+        "rm \"$${TEMP_FILE}\"",
+    ]),
+)
+```
+# TODO: Figure out why `ijar` cannot be patched
+# --- a/third_party/ijar/BUILD
+# +++ b/third_party/ijar/BUILD
+# @@ -70,22 +70,66 @@
+#  )
+ 
+#  cc_binary(
+# -    name = "zipper",
+# +    name = "zipper_orig",
+#      srcs = ["zip_main.cc"],
+# -    visibility = ["//visibility:public"],
+# +    visibility = ["//visibility:private"],
+#      deps = [":zip"],
+#  )
+ 
+# +genrule(
+# +    name = "zipper_cleaner",
+# +    srcs = [
+# +        ":zipper_orig",
+# +    ],
+# +    outs = ["zipper_"],
+# +    cmd = "\n".join([
+# +        "TEMP_FILE=\"$$(mktemp -t bazel.XXXXXXXX)\"",
+# +        "cp \"$(location :zipper_orig)\" \"$${TEMP_FILE}\"",
+# +        "termux-elf-cleaner --api-level=24 \"$${TEMP_FILE}\"",
+# +        "cp \"$${TEMP_FILE}\" \"$@\"",
+# +        "rm \"$${TEMP_FILE}\"",
+# +    ]),
+# +    visibility = ["//visibility:private"],
+# +)
+# +
+# +alias(
+# +    name = "zipper",
+# +    actual = ":zipper_",
+# +    visibility = ["//visibility:public"],
+# +)
+# +
+#  cc_binary(
+# -    name = "ijar",
+# +    name = "ijar_orig",
+#      srcs = [
+#          "classfile.cc",
+#          "ijar.cc",
+#      ],
+# -    visibility = ["//visibility:public"],
+# +    visibility = ["//visibility:private"],
+#      deps = [":zip"],
+#  )
+ 
+# +genrule(
+# +    name = "ijar_cleaner",
+# +    srcs = [
+# +        ":ijar_orig",
+# +    ],
+# +    outs = ["ijar_"],
+# +    cmd = "\n".join([
+# +        "TEMP_FILE=\"$$(mktemp -t bazel.XXXXXXXX)\"",
+# +        "cp \"$(location :ijar_orig)\" \"$${TEMP_FILE}\"",
+# +        "termux-elf-cleaner --api-level=24 \"$${TEMP_FILE}\"",
+# +        "cp \"$${TEMP_FILE}\" \"$@\"",
+# +        "rm \"$${TEMP_FILE}\"",
+# +    ]),
+# +    visibility = ["//visibility:private"],
+# +)
+# +
+# +alias(
+# +    name = "ijar",
+# +    actual = ":ijar_",
+# +    visibility = ["//visibility:public"],
+# +)
+# +
+#  filegroup(
+#      name = "srcs",
+#      srcs = glob(["**"]) + ["//third_party/ijar/test:srcs"],
+--- a/src/main/cpp/BUILD
++++ b/src/main/cpp/BUILD
+@@ -88,7 +89,7 @@
+ )
+
+ cc_binary(
+-    name = "client",
++    name = "client_orig",
+     srcs = [
+         "blaze.cc",
+         "blaze.h",
+@@ -138,6 +139,21 @@
+     ],
+ )
+
++genrule(
++    name = "client_cleaner",
++    srcs = [
++        ":client_orig",
++    ],
++    outs = ["client"],
++    cmd = "\n".join([
++        "TEMP_FILE=\"$$(mktemp -t bazel.XXXXXXXX)\"",
++        "cp \"$(location :client_orig)\" \"$${TEMP_FILE}\"",
++        "termux-elf-cleaner --api-level=24 \"$${TEMP_FILE}\"",
++        "cp \"$${TEMP_FILE}\" \"$@\"",
++        "rm \"$${TEMP_FILE}\"",
++    ]),
++)
++
+ cc_library(
+     name = "option_processor",
+     srcs = ["option_processor.cc"],
+--- a/src/main/tools/BUILD
++++ b/src/main/tools/BUILD
+@@ -1,13 +1,28 @@
+ package(default_visibility = ["//src:__subpackages__"])
+ 
+ cc_binary(
+-    name = "daemonize",
++    name = "daemonize_orig",
+     srcs = ["daemonize.cc"],
+     deps = [
+         ":process-tools",
+     ],
+ )
+ 
++genrule(
++    name = "daemonize_cleaner",
++    srcs = [
++        ":daemonize_orig",
++    ],
++    outs = ["daemonize"],
++    cmd = "\n".join([
++        "TEMP_FILE=\"$$(mktemp -t bazel.XXXXXXXX)\"",
++        "cp \"$(location :daemonize_orig)\" \"$${TEMP_FILE}\"",
++        "termux-elf-cleaner --api-level=24 \"$${TEMP_FILE}\"",
++        "cp \"$${TEMP_FILE}\" \"$@\"",
++        "rm \"$${TEMP_FILE}\"",
++    ]),
++)
++
+ cc_library(
+     name = "logging",
+     srcs = ["logging.cc"],
+@@ -29,7 +44,7 @@
+ )
+ 
+ cc_binary(
+-    name = "process-wrapper",
++    name = "process-wrapper_orig",
+     srcs = select({
+         "//src/conditions:windows": ["process-wrapper-windows.cc"],
+         "//conditions:default": [
+@@ -59,8 +74,23 @@
+     }),
+ )
+ 
++genrule(
++    name = "process-wrapper_cleaner",
++    srcs = [
++        ":process-wrapper_orig",
++    ],
++    outs = ["process-wrapper"],
++    cmd = "\n".join([
++        "TEMP_FILE=\"$$(mktemp -t bazel.XXXXXXXX)\"",
++        "cp \"$(location :process-wrapper_orig)\" \"$${TEMP_FILE}\"",
++        "termux-elf-cleaner --api-level=24 \"$${TEMP_FILE}\"",
++        "cp \"$${TEMP_FILE}\" \"$@\"",
++        "rm \"$${TEMP_FILE}\"",
++    ]),
++)
++
+ cc_binary(
+-    name = "build-runfiles",
++    name = "build-runfiles_orig",
+     srcs = select({
+         "//src/conditions:windows": ["build-runfiles-windows.cc"],
+         "//conditions:default": ["build-runfiles.cc"],
+@@ -71,8 +101,23 @@
+     }),
+ )
+ 
++genrule(
++    name = "build-runfiles_cleaner",
++    srcs = [
++        ":build-runfiles_orig",
++    ],
++    outs = ["build-runfiles"],
++    cmd = "\n".join([
++        "TEMP_FILE=\"$$(mktemp -t bazel.XXXXXXXX)\"",
++        "cp \"$(location :build-runfiles_orig)\" \"$${TEMP_FILE}\"",
++        "termux-elf-cleaner --api-level=24 \"$${TEMP_FILE}\"",
++        "cp \"$${TEMP_FILE}\" \"$@\"",
++        "rm \"$${TEMP_FILE}\"",
++    ]),
++)
++
+ cc_binary(
+-    name = "linux-sandbox",
++    name = "linux-sandbox_orig",
+     srcs = select({
+         "//src/conditions:darwin": ["dummy-sandbox.c"],
+         "//src/conditions:freebsd": ["dummy-sandbox.c"],
+@@ -111,6 +156,21 @@
+     }),
+ )
+ 
++genrule(
++    name = "linux-sandbox_cleaner",
++    srcs = [
++        ":linux-sandbox_orig",
++    ],
++    outs = ["linux-sandbox"],
++    cmd = "\n".join([
++        "TEMP_FILE=\"$$(mktemp -t bazel.XXXXXXXX)\"",
++        "cp \"$(location :linux-sandbox_orig)\" \"$${TEMP_FILE}\"",
++        "termux-elf-cleaner --api-level=24 \"$${TEMP_FILE}\"",
++        "cp \"$${TEMP_FILE}\" \"$@\"",
++        "rm \"$${TEMP_FILE}\"",
++    ]),
++)
++
+ exports_files([
+     "build_interface_so",
+ ])

--- a/tur/bazel8/0009-compile-cpu_profiler-with-fPIC.patch
+++ b/tur/bazel8/0009-compile-cpu_profiler-with-fPIC.patch
@@ -1,0 +1,8 @@
+--- a/src/main/java/net/starlark/java/eval/BUILD
++++ b/src/main/java/net/starlark/java/eval/BUILD
+@@ -109,4 +109,5 @@
+     }),
+     linkshared = 1,
+     deps = ["@bazel_tools//tools/jdk:jni"],
++    cxxopts = ["-fPIC"],
+ )

--- a/tur/bazel8/0101-import-termux-cross-deps.patch
+++ b/tur/bazel8/0101-import-termux-cross-deps.patch
@@ -1,0 +1,32 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -479,3 +479,29 @@
+         "patch -p1 -i termux-patches/rules_cc.patch",
+     ]
+ )
++
++new_local_repository_ = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
++
++new_local_repository_(
++    name = "termux-prefix",
++    path = "@TERMUX_PREFIX@",
++    build_file_content = """
++package(default_visibility = ["//visibility:public"])
++filegroup(
++    name = "prefix",
++    srcs = glob(["**"])
++)
++"""
++)
++
++new_local_repository_(
++    name = "termux-toolchain",
++    path = "@TERMUX_PREFIX@/tmp/custom-toolchain",
++    build_file_content = """
++package(default_visibility = ["//visibility:public"])
++filegroup(
++    name = "toolchain",
++    srcs = glob(["**"])
++)
++"""
++)

--- a/tur/bazel8/build.sh
+++ b/tur/bazel8/build.sh
@@ -1,5 +1,5 @@
 TERMUX_PKG_HOMEPAGE=https://bazel.build/
-TERMUX_PKG_DESCRIPTION="Correct, reproducible, and fast builds for everyone"
+TERMUX_PKG_DESCRIPTION="Correct, reproducible, and fast builds for everyone (Version 8)"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_VERSION="8.7.0"
@@ -185,7 +185,5 @@ termux_step_make() {
 }
 
 termux_step_make_install() {
-	install -Dm700 ./scripts/packages/bazel.sh $TERMUX_PREFIX/bin/bazel
-	install -Dm700 ./bazel-bin/src/bazel_nojdk $TERMUX_PREFIX/bin/bazel-real
 	install -Dm700 ./bazel-bin/src/bazel_nojdk $TERMUX_PREFIX/bin/bazel-$TERMUX_PKG_VERSION
 }

--- a/tur/bazel8/dep-patches/BUILD
+++ b/tur/bazel8/dep-patches/BUILD
@@ -1,0 +1,7 @@
+licenses(["notice"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//third_party:__pkg__"],
+)

--- a/tur/bazel8/dep-patches/absl.patch
+++ b/tur/bazel8/dep-patches/absl.patch
@@ -1,0 +1,29 @@
+--- a/absl/log/internal/log_sink_set.cc
++++ b/absl/log/internal/log_sink_set.cc
+@@ -19,7 +19,7 @@
+ #include <pthread.h>
+ #endif
+ 
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #include <android/log.h>
+ #endif
+ 
+@@ -116,7 +116,7 @@
+   }
+ };
+ 
+-#if defined(__ANDROID__)
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ class AndroidLogSink final : public LogSink {
+  public:
+   ~AndroidLogSink() override = default;
+@@ -172,7 +172,7 @@
+     static absl::NoDestructor<StderrLogSink> stderr_log_sink;
+     AddLogSink(stderr_log_sink.get());
+ #endif
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+     static absl::NoDestructor<AndroidLogSink> android_log_sink;
+     AddLogSink(android_log_sink.get());
+ #endif

--- a/tur/bazel8/dep-patches/cares-config.patch
+++ b/tur/bazel8/dep-patches/cares-config.patch
@@ -1,0 +1,11 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -54,7 +54,7 @@
+         ":darwin": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
+         ":windows": "@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h",
+         ":android": "@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h",
+-        "//conditions:default": "@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h",
++        "//conditions:default": "@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h",
+     }),
+     out = "ares_config.h",
+ )

--- a/tur/bazel8/dep-patches/cares.patch
+++ b/tur/bazel8/dep-patches/cares.patch
@@ -1,0 +1,94 @@
+https://github.com/termux/termux-packages/tree/88d3e0f154a40740a0a09822fac96450a360b01f/packages/c-ares
+
+--- a/ares_android.c
++++ b/ares_android.c
+@@ -12,7 +12,7 @@
+  * this software for any purpose.  It is provided "as is"
+  * without express or implied warranty.
+  */
+-#if defined(ANDROID) || defined(__ANDROID__)
++#if defined(__DISABLED_IN_TERMUX__)
+ 
+ #include <jni.h>
+ 
+--- a/ares_init.c
++++ b/ares_init.c
+@@ -44,7 +44,6 @@
+ 
+ #if defined(ANDROID) || defined(__ANDROID__)
+ #include <sys/system_properties.h>
+-#include "ares_android.h"
+ /* From the Bionic sources */
+ #define DNS_PROP_NAME_PREFIX  "net.dns"
+ #define MAX_DNS_PROPERTIES    8
+@@ -1549,35 +1548,6 @@
+   char *domains;
+   size_t num_servers;
+ 
+-  /* Use the Android connectivity manager to get a list
+-   * of DNS servers. As of Android 8 (Oreo) net.dns#
+-   * system properties are no longer available. Google claims this
+-   * improves privacy. Apps now need the ACCESS_NETWORK_STATE
+-   * permission and must use the ConnectivityManager which
+-   * is Java only. */
+-  dns_servers = ares_get_android_server_list(MAX_DNS_PROPERTIES, &num_servers);
+-  if (dns_servers != NULL)
+-  {
+-    for (i = 0; i < num_servers; i++)
+-    {
+-      status = config_nameserver(&servers, &nservers, dns_servers[i]);
+-      if (status != ARES_SUCCESS)
+-        break;
+-      status = ARES_EOF;
+-    }
+-    for (i = 0; i < num_servers; i++)
+-    {
+-      ares_free(dns_servers[i]);
+-    }
+-    ares_free(dns_servers);
+-  }
+-  if (channel->ndomains == -1)
+-  {
+-    domains = ares_get_android_search_domains_list();
+-    set_search(channel, domains);
+-    ares_free(domains);
+-  }
+-
+ #  ifdef HAVE___SYSTEM_PROPERTY_GET
+   /* Old way using the system property still in place as
+    * a fallback. Older android versions can still use this.
+--- a/ares_library_init.c
++++ b/ares_library_init.c
+@@ -30,10 +30,6 @@
+ fpGetBestRoute2_t ares_fpGetBestRoute2 = ZERO_NULL;
+ #endif
+ 
+-#if defined(ANDROID) || defined(__ANDROID__)
+-#include "ares_android.h"
+-#endif
+-
+ /* library-private global vars with source visibility restricted to this file */
+ 
+ static unsigned int ares_initialized;
+@@ -174,10 +170,6 @@
+   if (ares_init_flags & ARES_LIB_INIT_WIN32)
+     ares_win32_cleanup();
+ 
+-#if defined(ANDROID) || defined(__ANDROID__)
+-  ares_library_cleanup_android();
+-#endif
+-
+   ares_init_flags = ARES_LIB_INIT_NONE;
+   ares_malloc = malloc;
+   ares_realloc = realloc;
+--- a/ares_private.h
++++ b/ares_private.h
+@@ -84,7 +84,7 @@
+ #ifdef ETC_INET
+ #define PATH_HOSTS              "/etc/inet/hosts"
+ #else
+-#define PATH_HOSTS              "/etc/hosts"
++#define PATH_HOSTS              "/data/data/com.termux/files/usr/etc/hosts"
+ #endif
+ 
+ #endif

--- a/tur/bazel8/dep-patches/grpc.patch
+++ b/tur/bazel8/dep-patches/grpc.patch
@@ -1,0 +1,69 @@
+https://github.com/termux/termux-packages/tree/18bc97d74656ade33269bea1dbbe2ae5d8c50f57/packages/libgrpc
+
+--- a/src/core/util/posix/tmpfile.cc
++++ b/src/core/util/posix/tmpfile.cc
+@@ -43,7 +43,7 @@ FILE* gpr_tmpfile(const char* prefix, char** tmp_filename) {
+ 
+   if (tmp_filename != nullptr) *tmp_filename = nullptr;
+ 
+-  gpr_asprintf(&filename_template, "/tmp/%s_XXXXXX", prefix);
++  gpr_asprintf(&filename_template, "/data/data/com.termux/files/usr/tmp/%s_XXXXXX", prefix);
+   CHECK_NE(filename_template, nullptr);
+ 
+   fd = mkstemp(filename_template);
+--- a/src/core/lib/security/security_connector/load_system_roots_supported.cc
++++ b/src/core/lib/security/security_connector/load_system_roots_supported.cc
+@@ -52,12 +52,12 @@
+ 
+ #if defined(GPR_LINUX) || defined(GPR_ANDROID)
+ const char* kCertFiles[] = {
+-    "/etc/ssl/certs/ca-certificates.crt", "/etc/pki/tls/certs/ca-bundle.crt",
+-    "/etc/ssl/ca-bundle.pem", "/etc/pki/tls/cacert.pem",
+-    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"};
++    "/data/data/com.termux/files/usr/etc/ssl/certs/ca-certificates.crt", "/data/data/com.termux/files/usr/etc/pki/tls/certs/ca-bundle.crt",
++    "/data/data/com.termux/files/usr/etc/ssl/ca-bundle.pem", "/data/data/com.termux/files/usr/etc/pki/tls/cacert.pem",
++    "/data/data/com.termux/files/usr/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"};
+ const char* kCertDirectories[] = {
+-    "/etc/ssl/certs", "/system/etc/security/cacerts", "/usr/local/share/certs",
+-    "/etc/pki/tls/certs", "/etc/openssl/certs"};
++    "/data/data/com.termux/files/usr/etc/ssl/certs", "/data/data/com.termux/files/usr/share/certs",
++    "/data/data/com.termux/files/usr/etc/pki/tls/certs", "/data/data/com.termux/files/usr/etc/openssl/certs"};
+ #elif defined(GPR_FREEBSD)  // endif GPR_LINUX || GPR_ANDROID
+ const char* kCertFiles[] = {"/etc/ssl/cert.pem",
+                             "/usr/local/share/certs/ca-root-nss.crt"};
+--- a/src/core/lib/security/security_connector/ssl_utils.cc
++++ b/src/core/lib/security/security_connector/ssl_utils.cc
+@@ -45,9 +45,9 @@
+ static const char* installed_roots_path = GRPC_ROOT_PEM_PATH;
+ #elif defined(INSTALL_PREFIX)
+ static const char* installed_roots_path =
+-    INSTALL_PREFIX "/usr/share/grpc/roots.pem";
++    "/data/data/com.termux/files/usr/share/grpc/roots.pem";
+ #else
+-static const char* installed_roots_path = "/usr/share/grpc/roots.pem";
++static const char* installed_roots_path = "/data/data/com.termux/files/usr/share/grpc/roots.pem";
+ #endif
+
+ #ifndef TSI_OPENSSL_ALPN_SUPPORT
+--- a/src/core/util/posix/log.cc
++++ b/src/core/util/posix/log.cc
+@@ -18,7 +18,7 @@
+ 
+ #include <grpc/support/port_platform.h>
+ 
+-#ifdef GPR_POSIX_LOG
++#if defined(GPR_POSIX_LOG) || defined(__TERMUX__)
+ 
+ #include <inttypes.h>
+ #include <pthread.h>
+--- a/src/core/util/android/log.cc
++++ b/src/core/util/android/log.cc
+@@ -18,7 +18,7 @@
+ 
+ #include <grpc/support/port_platform.h>
+ 
+-#ifdef GPR_ANDROID
++#if defined(GPR_ANDROID) && !defined(__TERMUX__)
+ 
+ #include <android/log.h>
+ #include <stdarg.h>

--- a/tur/bazel8/dep-patches/protobuf.patch
+++ b/tur/bazel8/dep-patches/protobuf.patch
@@ -1,0 +1,11 @@
+--- a/src/google/protobuf/stubs/common.cc
++++ b/src/google/protobuf/stubs/common.cc
+@@ -45,7 +45,7 @@
+ #include <windows.h>
+ #define snprintf _snprintf    // see comment in strutil.cc
+ #endif
+-#if defined(__ANDROID__)
++#if defined(__ANDROID__) && !defined(__TERMUX__)
+ #include <android/log.h>
+ #endif
+ 

--- a/tur/bazel8/dep-patches/rules_cc.patch
+++ b/tur/bazel8/dep-patches/rules_cc.patch
@@ -1,0 +1,13 @@
+Force disable module_maps as it doesn't support on Termux
+
+--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
++++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
+@@ -37,7 +37,7 @@ def _target_os_version(ctx):
+     return xcode_config.minimum_os_for_platform_type(platform_type)
+ 
+ def layering_check_features(compiler, extra_flags_per_feature, is_macos):
+-    if compiler != "clang":
++    if True:
+         return []
+     return [
+         feature(

--- a/tur/bazel8/dep-patches/z-absl.patch
+++ b/tur/bazel8/dep-patches/z-absl.patch
@@ -1,0 +1,32 @@
+--- /dev/null
++++ b/termux-patches/absl.patch
+@@ -0,0 +1,29 @@
++--- a/absl/log/internal/log_sink_set.cc
+++++ b/absl/log/internal/log_sink_set.cc
++@@ -19,7 +19,7 @@
++ #include <pthread.h>
++ #endif
++ 
++-#ifdef __ANDROID__
+++#if defined(__ANDROID__) && !defined(__TERMUX__)
++ #include <android/log.h>
++ #endif
++ 
++@@ -116,7 +116,7 @@
++   }
++ };
++ 
++-#if defined(__ANDROID__)
+++#if defined(__ANDROID__) && !defined(__TERMUX__)
++ class AndroidLogSink final : public LogSink {
++  public:
++   ~AndroidLogSink() override = default;
++@@ -172,7 +172,7 @@
++     static absl::NoDestructor<StderrLogSink> stderr_log_sink;
++     AddLogSink(stderr_log_sink.get());
++ #endif
++-#ifdef __ANDROID__
+++#if defined(__ANDROID__) && !defined(__TERMUX__)
++     static absl::NoDestructor<AndroidLogSink> android_log_sink;
++     AddLogSink(android_log_sink.get());
++ #endif

--- a/tur/bazel8/dep-patches/z-cares-config.patch
+++ b/tur/bazel8/dep-patches/z-cares-config.patch
@@ -1,0 +1,14 @@
+--- /dev/null
++++ b/termux-patches/cares-config.patch
+@@ -0,0 +1,11 @@
++--- a/BUILD.bazel
+++++ b/BUILD.bazel
++@@ -54,7 +54,7 @@
++         ":darwin": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
++         ":windows": "@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h",
++         ":android": "@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h",
++-        "//conditions:default": "@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h",
+++        "//conditions:default": "@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h",
++     }),
++     out = "ares_config.h",
++ )

--- a/tur/bazel8/dep-patches/z-cares.patch
+++ b/tur/bazel8/dep-patches/z-cares.patch
@@ -1,0 +1,97 @@
+--- /dev/null
++++ b/termux-patches/cares.patch
+@@ -0,0 +1,94 @@
++https://github.com/termux/termux-packages/tree/88d3e0f154a40740a0a09822fac96450a360b01f/packages/c-ares
++
++--- a/ares_android.c
+++++ b/ares_android.c
++@@ -12,7 +12,7 @@
++  * this software for any purpose.  It is provided "as is"
++  * without express or implied warranty.
++  */
++-#if defined(ANDROID) || defined(__ANDROID__)
+++#if defined(__DISABLED_IN_TERMUX__)
++ 
++ #include <jni.h>
++ 
++--- a/ares_init.c
+++++ b/ares_init.c
++@@ -44,7 +44,6 @@
++ 
++ #if defined(ANDROID) || defined(__ANDROID__)
++ #include <sys/system_properties.h>
++-#include "ares_android.h"
++ /* From the Bionic sources */
++ #define DNS_PROP_NAME_PREFIX  "net.dns"
++ #define MAX_DNS_PROPERTIES    8
++@@ -1549,35 +1548,6 @@
++   char *domains;
++   size_t num_servers;
++ 
++-  /* Use the Android connectivity manager to get a list
++-   * of DNS servers. As of Android 8 (Oreo) net.dns#
++-   * system properties are no longer available. Google claims this
++-   * improves privacy. Apps now need the ACCESS_NETWORK_STATE
++-   * permission and must use the ConnectivityManager which
++-   * is Java only. */
++-  dns_servers = ares_get_android_server_list(MAX_DNS_PROPERTIES, &num_servers);
++-  if (dns_servers != NULL)
++-  {
++-    for (i = 0; i < num_servers; i++)
++-    {
++-      status = config_nameserver(&servers, &nservers, dns_servers[i]);
++-      if (status != ARES_SUCCESS)
++-        break;
++-      status = ARES_EOF;
++-    }
++-    for (i = 0; i < num_servers; i++)
++-    {
++-      ares_free(dns_servers[i]);
++-    }
++-    ares_free(dns_servers);
++-  }
++-  if (channel->ndomains == -1)
++-  {
++-    domains = ares_get_android_search_domains_list();
++-    set_search(channel, domains);
++-    ares_free(domains);
++-  }
++-
++ #  ifdef HAVE___SYSTEM_PROPERTY_GET
++   /* Old way using the system property still in place as
++    * a fallback. Older android versions can still use this.
++--- a/ares_library_init.c
+++++ b/ares_library_init.c
++@@ -30,10 +30,6 @@
++ fpGetBestRoute2_t ares_fpGetBestRoute2 = ZERO_NULL;
++ #endif
++ 
++-#if defined(ANDROID) || defined(__ANDROID__)
++-#include "ares_android.h"
++-#endif
++-
++ /* library-private global vars with source visibility restricted to this file */
++ 
++ static unsigned int ares_initialized;
++@@ -174,10 +170,6 @@
++   if (ares_init_flags & ARES_LIB_INIT_WIN32)
++     ares_win32_cleanup();
++ 
++-#if defined(ANDROID) || defined(__ANDROID__)
++-  ares_library_cleanup_android();
++-#endif
++-
++   ares_init_flags = ARES_LIB_INIT_NONE;
++   ares_malloc = malloc;
++   ares_realloc = realloc;
++--- a/ares_private.h
+++++ b/ares_private.h
++@@ -84,7 +84,7 @@
++ #ifdef ETC_INET
++ #define PATH_HOSTS              "/etc/inet/hosts"
++ #else
++-#define PATH_HOSTS              "/etc/hosts"
+++#define PATH_HOSTS              "/data/data/com.termux/files/usr/etc/hosts"
++ #endif
++ 
++ #endif

--- a/tur/bazel8/dep-patches/z-grpc.patch
+++ b/tur/bazel8/dep-patches/z-grpc.patch
@@ -1,0 +1,72 @@
+--- /dev/null
++++ b/termux-patches/grpc.patch
+@@ -0,0 +1,69 @@
++https://github.com/termux/termux-packages/tree/18bc97d74656ade33269bea1dbbe2ae5d8c50f57/packages/libgrpc
++
++--- a/src/core/util/posix/tmpfile.cc
+++++ b/src/core/util/posix/tmpfile.cc
++@@ -43,7 +43,7 @@ FILE* gpr_tmpfile(const char* prefix, char** tmp_filename) {
++ 
++   if (tmp_filename != nullptr) *tmp_filename = nullptr;
++ 
++-  gpr_asprintf(&filename_template, "/tmp/%s_XXXXXX", prefix);
+++  gpr_asprintf(&filename_template, "/data/data/com.termux/files/usr/tmp/%s_XXXXXX", prefix);
++   CHECK_NE(filename_template, nullptr);
++ 
++   fd = mkstemp(filename_template);
++--- a/src/core/lib/security/security_connector/load_system_roots_supported.cc
+++++ b/src/core/lib/security/security_connector/load_system_roots_supported.cc
++@@ -52,12 +52,12 @@
++ 
++ #if defined(GPR_LINUX) || defined(GPR_ANDROID)
++ const char* kCertFiles[] = {
++-    "/etc/ssl/certs/ca-certificates.crt", "/etc/pki/tls/certs/ca-bundle.crt",
++-    "/etc/ssl/ca-bundle.pem", "/etc/pki/tls/cacert.pem",
++-    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"};
+++    "/data/data/com.termux/files/usr/etc/ssl/certs/ca-certificates.crt", "/data/data/com.termux/files/usr/etc/pki/tls/certs/ca-bundle.crt",
+++    "/data/data/com.termux/files/usr/etc/ssl/ca-bundle.pem", "/data/data/com.termux/files/usr/etc/pki/tls/cacert.pem",
+++    "/data/data/com.termux/files/usr/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"};
++ const char* kCertDirectories[] = {
++-    "/etc/ssl/certs", "/system/etc/security/cacerts", "/usr/local/share/certs",
++-    "/etc/pki/tls/certs", "/etc/openssl/certs"};
+++    "/data/data/com.termux/files/usr/etc/ssl/certs", "/data/data/com.termux/files/usr/share/certs",
+++    "/data/data/com.termux/files/usr/etc/pki/tls/certs", "/data/data/com.termux/files/usr/etc/openssl/certs"};
++ #elif defined(GPR_FREEBSD)  // endif GPR_LINUX || GPR_ANDROID
++ const char* kCertFiles[] = {"/etc/ssl/cert.pem",
++                             "/usr/local/share/certs/ca-root-nss.crt"};
++--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++++ b/src/core/lib/security/security_connector/ssl_utils.cc
++@@ -45,9 +45,9 @@
++ static const char* installed_roots_path = GRPC_ROOT_PEM_PATH;
++ #elif defined(INSTALL_PREFIX)
++ static const char* installed_roots_path =
++-    INSTALL_PREFIX "/usr/share/grpc/roots.pem";
+++    "/data/data/com.termux/files/usr/share/grpc/roots.pem";
++ #else
++-static const char* installed_roots_path = "/usr/share/grpc/roots.pem";
+++static const char* installed_roots_path = "/data/data/com.termux/files/usr/share/grpc/roots.pem";
++ #endif
++
++ #ifndef TSI_OPENSSL_ALPN_SUPPORT
++--- a/src/core/util/posix/log.cc
+++++ b/src/core/util/posix/log.cc
++@@ -18,7 +18,7 @@
++ 
++ #include <grpc/support/port_platform.h>
++ 
++-#ifdef GPR_POSIX_LOG
+++#if defined(GPR_POSIX_LOG) || defined(__TERMUX__)
++ 
++ #include <inttypes.h>
++ #include <pthread.h>
++--- a/src/core/util/android/log.cc
+++++ b/src/core/util/android/log.cc
++@@ -18,7 +18,7 @@
++ 
++ #include <grpc/support/port_platform.h>
++ 
++-#ifdef GPR_ANDROID
+++#if defined(GPR_ANDROID) && !defined(__TERMUX__)
++ 
++ #include <android/log.h>
++ #include <stdarg.h>

--- a/tur/bazel8/dep-patches/z-protobuf.patch
+++ b/tur/bazel8/dep-patches/z-protobuf.patch
@@ -1,0 +1,14 @@
+--- /dev/null
++++ b/termux-patches/protobuf.patch
+@@ -0,0 +1,11 @@
++--- a/src/google/protobuf/stubs/common.cc
+++++ b/src/google/protobuf/stubs/common.cc
++@@ -45,7 +45,7 @@
++ #include <windows.h>
++ #define snprintf _snprintf    // see comment in strutil.cc
++ #endif
++-#if defined(__ANDROID__)
+++#if defined(__ANDROID__) && !defined(__TERMUX__)
++ #include <android/log.h>
++ #endif
++ 

--- a/tur/bazel8/dep-patches/z-rules_cc.patch
+++ b/tur/bazel8/dep-patches/z-rules_cc.patch
@@ -1,0 +1,16 @@
+--- /dev/null
++++ b/termux-patches/rules_cc.patch
+@@ -0,0 +1,13 @@
++Force disable module_maps as it doesn't support on Termux
++
++--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
++@@ -37,7 +37,7 @@ def _target_os_version(ctx):
++     return xcode_config.minimum_os_for_platform_type(platform_type)
++ 
++ def layering_check_features(compiler, extra_flags_per_feature, is_macos):
++-    if compiler != "clang":
+++    if True:
++         return []
++     return [
++         feature(

--- a/tur/bazel8/termux-cross/platforms/BUILD
+++ b/tur/bazel8/termux-cross/platforms/BUILD
@@ -1,0 +1,52 @@
+package(default_visibility = ["//visibility:public"])
+
+constraint_setting(
+    name = "target_app",
+    default_constraint_value = ":unknown",
+)
+
+constraint_value(
+    name = "termux",
+    constraint_setting = ":target_app",
+)
+
+constraint_value(
+    name = "unknown",
+    constraint_setting = ":target_app",
+)
+
+platform(
+    name = "termux_aarch64",
+    constraint_values = [
+        ":termux",
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "termux_arm",
+    constraint_values = [
+        ":termux",
+        "@platforms//cpu:armv7",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "termux_i686",
+    constraint_values = [
+        ":termux",
+        "@platforms//cpu:i686",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "termux_x86_64",
+    constraint_values = [
+        ":termux",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)

--- a/tur/bazel8/termux-cross/toolchain/template/BUILD
+++ b/tur/bazel8/termux-cross/toolchain/template/BUILD
@@ -1,0 +1,51 @@
+package(default_visibility = ["//visibility:public"])
+
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+
+filegroup(name = "empty")
+
+filegroup(
+  name = "bootstrap",
+  srcs = glob(["bin/**"]) + [
+    "@termux-toolchain//:toolchain",
+    "@termux-prefix//:prefix",
+  ],
+)
+
+cc_toolchain_config(name = "@TERMUX_ARCH@_toolchain_config")
+
+cc_toolchain(
+    name = "@TERMUX_ARCH@_toolchain",
+    toolchain_identifier = "@TERMUX_ARCH@-toolchain",
+    toolchain_config = ":@TERMUX_ARCH@_toolchain_config",
+    all_files = ":bootstrap",
+    ar_files = ":bootstrap",
+    compiler_files = ":bootstrap",
+    dwp_files = ":bootstrap",
+    linker_files = ":bootstrap",
+    objcopy_files = ":bootstrap",
+    strip_files = ":bootstrap",
+)
+
+cc_toolchain_suite(
+    name = "gcc_toolchain",
+    toolchains = {
+        "@TERMUX_ARCH@": ":@TERMUX_ARCH@_toolchain",
+    },
+    tags = ["manual"]
+)
+
+toolchain(
+    name = "@TERMUX_ARCH@_linux_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@//termux-cross/platforms:termux",
+        "@platforms//os:linux",
+        "@platforms//cpu:@TERMUX_ARCH@",
+    ],
+    toolchain = ":@TERMUX_ARCH@_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/tur/bazel8/termux-cross/toolchain/template/bin/wrapper.sh
+++ b/tur/bazel8/termux-cross/toolchain/template/bin/wrapper.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec external/+_repo_rules6+termux-toolchain/bin/$(basename "$0")  "$@"

--- a/tur/bazel8/termux-cross/toolchain/template/cc_toolchain_config.bzl
+++ b/tur/bazel8/termux-cross/toolchain/template/cc_toolchain_config.bzl
@@ -1,0 +1,132 @@
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool_path",
+)
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+all_compile_actions = [
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.lto_backend,
+    ACTION_NAMES.preprocess_assemble,
+]
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "ar",
+            path = "bin/@AR@",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "bin/@CPP@",
+        ),
+        tool_path(
+            name = "gcc",
+            path = "bin/@CC@",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "g++",
+            path = "bin/@CXX@",
+        ),
+        tool_path(
+            name = "ld",
+            path = "bin/@LD@",
+        ),
+        tool_path(
+            name = "nm",
+            path = "bin/@NM@",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "bin/@OBJDUMP@",
+        ),
+        tool_path(
+            name = "strip",
+            path = "bin/@STRIP@",
+        ),
+    ]
+
+    default_compiler_flags = feature(
+        name = "default_compiler_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            # "--verbose",
+                            "-fPIC",
+                            "--sysroot=external/+_repo_rules6+termux-toolchain/sysroot",
+                            "-isystemexternal/+_repo_rules6+termux-prefix/include",
+                            "-no-canonical-prefixes",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    default_linker_flags = feature(
+        name = "default_linker_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-Wl,-rpath=@TERMUX_PREFIX@/lib",
+                            "-Lexternal/+_repo_rules6+termux-prefix/lib",
+                            "--sysroot=external/+_repo_rules6+termux-toolchain/sysroot/",
+                            "-lc++_shared",
+                        ],
+                    ),
+                ]),
+            ),
+        ],
+    )
+
+    features = [
+        default_compiler_flags,
+        default_linker_flags,
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        toolchain_identifier = "@TERMUX_ARCH@-toolchain",
+        host_system_name = "local",
+        target_system_name = "unknown",
+        target_cpu = "unknown",
+        target_libc = "unknown",
+        compiler = "unknown",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+    )
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)


### PR DESCRIPTION
Bazel 9 was [released in Jan 2026](https://blog.bazel.build/2026/01/20/bazel-9.html) and here we are half a year later still stuck on Bazel 8 in TUR.

We should bump the `bazel` package to the 9.x LTS but before that we should archive the current major version as `bazle8`, following the convention established by previous major version bumps.

This PR was created simply by:

- deleting the subpackage
- duplicating the `bazel` package into `bazel8`
- adding the version description suffix, and bumping the revision
- removing the two unversioned install commands in `termux_step_make_install`

Will submit follow-up PR for rolling the `bazel` package to 9.x after this is merged.