### PR TITLE
bump(tur/coded): 0.1.3

### DIFF
--- a/tur/coded/build.sh
+++ b/tur/coded/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/HashShin/coded
 TERMUX_PKG_DESCRIPTION="A mobile-first code editor that runs in your browser"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@HashShin"
-TERMUX_PKG_VERSION="0.1.2"
+TERMUX_PKG_VERSION="0.1.3"
 TERMUX_PKG_SRCURL="https://github.com/HashShin/coded/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz"
-TERMUX_PKG_SHA256=ee7595713c0035356dfc23ae6705689fc8864d47574f29300bdb4a619327057b
+TERMUX_PKG_SHA256=2b85e6b795623cb3ba8531245c3778012d7bb9b9522ea03b766f2ec99c277573
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 
@@ -15,7 +15,7 @@ termux_step_pre_configure() {
 termux_step_make() {
 	go build \
 		-trimpath \
-		-ldflags="-s -w" \
+		-ldflags="-s -w -X main.version=${TERMUX_PKG_VERSION}" \
 		-o coded \
 		.
 }


### PR DESCRIPTION
- Bump to 0.1.3
- Add `-X main.version=${TERMUX_PKG_VERSION}` to ldflags so `coded -version` reports the correct version