### PR TITLE
addpkg(tur/qemu-system-i386-10): 10.2.1

### DIFF
--- a/tur/qemu-system-i386-10/0000-android-config-support.patch
+++ b/tur/qemu-system-i386-10/0000-android-config-support.patch
@@ -1,0 +1,12 @@
+diff -uNr qemu-8.2.5/meson.build qemu-8.2.5.mod/meson.build
+--- qemu-8.2.5/meson.build	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/meson.build	2024-06-12 22:53:15.131884081 +0300
+@@ -2883,7 +2883,7 @@
+   'loongarch' : ['CONFIG_LOONGARCH_DIS'],
+ }
+ 
+-have_ivshmem = config_host_data.get('CONFIG_EVENTFD')
++have_ivshmem = false
+ host_kconfig = \
+   (get_option('fuzzing') ? ['CONFIG_FUZZ=y'] : []) + \
+   (have_tpm ? ['CONFIG_TPM=y'] : []) + \

--- a/tur/qemu-system-i386-10/0001-fix-hardcoded-paths.patch
+++ b/tur/qemu-system-i386-10/0001-fix-hardcoded-paths.patch
@@ -1,0 +1,213 @@
+diff -uNr qemu-8.2.5/tcg/perf.c qemu-8.2.5.mod/tcg/perf.c
+--- qemu-8.2.5/tcg/perf.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/tcg/perf.c	2024-06-12 21:43:13.385221419 +0300
+@@ -50,7 +50,7 @@
+ {
+     char map_file[32];
+ 
+-    snprintf(map_file, sizeof(map_file), "/tmp/perf-%d.map", getpid());
++    snprintf(map_file, sizeof(map_file), "@TERMUX_PREFIX@/tmp/perf-%d.map", getpid());
+     perfmap = safe_fopen_w(map_file);
+     if (perfmap == NULL) {
+         warn_report("Could not open %s: %s, proceeding without perfmap",
+diff -uNr qemu-8.2.5/block/gluster.c qemu-8.2.5.mod/block/gluster.c
+--- qemu-8.2.5/block/gluster.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/block/gluster.c	2024-06-12 21:43:13.385221419 +0300
+@@ -707,7 +707,7 @@
+                              "file.server.0.host=1.2.3.4,"
+                              "file.server.0.port=24007,"
+                              "file.server.1.transport=unix,"
+-                             "file.server.1.path=/var/run/glusterd.socket ..."
++                             "file.server.1.path=@TERMUX_PREFIX@/var/run/glusterd.socket ..."
+                              "\n");
+             return ret;
+         }
+diff -uNr qemu-8.2.5/block.c qemu-8.2.5.mod/block.c
+--- qemu-8.2.5/block.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/block.c	2024-06-12 21:43:13.389221438 +0300
+@@ -861,7 +861,7 @@
+      * /var/tmp is usually on a disk, so more appropriate for disk images.
+      */
+     if (!g_strcmp0(tmpdir, "/tmp")) {
+-        tmpdir = "/var/tmp";
++        tmpdir = "@TERMUX_PREFIX@/tmp";
+     }
+ #endif
+ 
+diff -uNr qemu-8.2.5/contrib/ivshmem-server/main.c qemu-8.2.5.mod/contrib/ivshmem-server/main.c
+--- qemu-8.2.5/contrib/ivshmem-server/main.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/contrib/ivshmem-server/main.c	2024-06-12 21:43:13.389221438 +0300
+@@ -14,8 +14,8 @@
+ 
+ #define IVSHMEM_SERVER_DEFAULT_VERBOSE        0
+ #define IVSHMEM_SERVER_DEFAULT_FOREGROUND     0
+-#define IVSHMEM_SERVER_DEFAULT_PID_FILE       "/var/run/ivshmem-server.pid"
+-#define IVSHMEM_SERVER_DEFAULT_UNIX_SOCK_PATH "/tmp/ivshmem_socket"
++#define IVSHMEM_SERVER_DEFAULT_PID_FILE       "@TERMUX_PREFIX@/var/run/ivshmem-server.pid"
++#define IVSHMEM_SERVER_DEFAULT_UNIX_SOCK_PATH "@TERMUX_PREFIX@/tmp/ivshmem_socket"
+ #define IVSHMEM_SERVER_DEFAULT_SHM_PATH       "ivshmem"
+ #define IVSHMEM_SERVER_DEFAULT_SHM_SIZE       (4 * 1024 * 1024)
+ #define IVSHMEM_SERVER_DEFAULT_N_VECTORS      1
+diff -uNr qemu-8.2.5/hw/hppa/machine.c qemu-8.2.5.mod/hw/hppa/machine.c
+--- qemu-8.2.5/hw/hppa/machine.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/hw/hppa/machine.c	2024-06-12 21:43:54.585416673 +0300
+@@ -207,37 +207,37 @@ static FWCfgState *create_fw_cfg(MachineState *ms, PCIBus *pci_bus,
+     fw_cfg_add_i64(fw_cfg, FW_CFG_RAM_SIZE, ms->ram_size);
+ 
+     val = cpu_to_le64(MIN_SEABIOS_HPPA_VERSION);
+-    fw_cfg_add_file(fw_cfg, "/etc/firmware-min-version",
++    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/firmware-min-version",
+                     g_memdup2(&val, sizeof(val)), sizeof(val));
+ 
+     val = cpu_to_le64(HPPA_TLB_ENTRIES - btlb_entries);
+-    fw_cfg_add_file(fw_cfg, "/etc/cpu/tlb_entries",
++    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/cpu/tlb_entries",
+                     g_memdup2(&val, sizeof(val)), sizeof(val));
+ 
+     val = cpu_to_le64(btlb_entries);
+-    fw_cfg_add_file(fw_cfg, "/etc/cpu/btlb_entries",
++    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/cpu/btlb_entries",
+                     g_memdup2(&val, sizeof(val)), sizeof(val));
+ 
+     len = strlen(mc->name) + 1;
+-    fw_cfg_add_file(fw_cfg, "/etc/hppa/machine",
++    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/hppa/machine",
+                     g_memdup2(mc->name, len), len);
+ 
+     val = cpu_to_le64(soft_power_reg);
+-    fw_cfg_add_file(fw_cfg, "/etc/hppa/power-button-addr",
++    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/hppa/power-button-addr",
+                     g_memdup2(&val, sizeof(val)), sizeof(val));
+ 
+     val = cpu_to_le64(CPU_HPA + 16);
+-    fw_cfg_add_file(fw_cfg, "/etc/hppa/rtc-addr",
++    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/hppa/rtc-addr",
+                     g_memdup2(&val, sizeof(val)), sizeof(val));
+ 
+     val = cpu_to_le64(CPU_HPA + 24);
+-    fw_cfg_add_file(fw_cfg, "/etc/hppa/DebugOutputPort",
++    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/hppa/DebugOutputPort",
+                     g_memdup2(&val, sizeof(val)), sizeof(val));
+ 
+     fw_cfg_add_i16(fw_cfg, FW_CFG_BOOT_DEVICE, ms->boot_config.order[0]);
+     qemu_register_boot_set(fw_cfg_boot_set, fw_cfg);
+ 
+-    fw_cfg_add_file(fw_cfg, "/etc/qemu-version",
++    fw_cfg_add_file(fw_cfg, "@TERMUX_PREFIX@/etc/qemu-version",
+                     g_memdup2(qemu_version, sizeof(qemu_version)),
+                     sizeof(qemu_version));
+ 
+diff -uNr qemu-8.2.5/hw/usb/ccid-card-emulated.c qemu-8.2.5.mod/hw/usb/ccid-card-emulated.c
+--- qemu-8.2.5/hw/usb/ccid-card-emulated.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/hw/usb/ccid-card-emulated.c	2024-06-12 21:43:13.389221438 +0300
+@@ -417,7 +417,7 @@
+     event_notifier_cleanup(&card->notifier);
+ }
+ 
+-#define CERTIFICATES_DEFAULT_DB "/etc/pki/nssdb"
++#define CERTIFICATES_DEFAULT_DB "@TERMUX_PREFIX@/etc/pki/nssdb"
+ #define CERTIFICATES_ARGS_TEMPLATE\
+     "db=\"%s\" use_hw=no soft=(,Virtual Reader,CAC,,%s,%s,%s)"
+ 
+diff -uNr qemu-8.2.5/linux-user/main.c qemu-8.2.5.mod/linux-user/main.c
+--- qemu-8.2.5/linux-user/main.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/linux-user/main.c	2024-06-12 21:43:13.389221438 +0300
+@@ -519,7 +519,7 @@
+      "",           "assume CALL0 Xtensa ABI"},
+ #endif
+     {"perfmap",    "QEMU_PERFMAP",     false, handle_arg_perfmap,
+-     "",           "Generate a /tmp/perf-${pid}.map file for perf"},
++     "",           "Generate a @TERMUX_PREFIX@/tmp/perf-${pid}.map file for perf"},
+     {"jitdump",    "QEMU_JITDUMP",     false, handle_arg_jitdump,
+      "",           "Generate a jit-${pid}.dump file for perf"},
+     {NULL, NULL, false, NULL, NULL, NULL}
+diff -uNr qemu-8.2.5/linux-user/syscall.c qemu-8.2.5.mod/linux-user/syscall.c
+--- qemu-8.2.5/linux-user/syscall.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/linux-user/syscall.c	2024-06-12 21:43:13.389221438 +0300
+@@ -8380,7 +8380,7 @@
+             /* create temporary file to map stat to */
+             tmpdir = getenv("TMPDIR");
+             if (!tmpdir)
+-                tmpdir = "/tmp";
++                tmpdir = "@TERMUX_PREFIX@/tmp";
+             snprintf(filename, sizeof(filename), "%s/qemu-open.XXXXXX", tmpdir);
+             fd = mkstemp(filename);
+             if (fd < 0) {
+diff -uNr qemu-8.2.5/migration/migration.c qemu-8.2.5.mod/migration/migration.c
+--- qemu-8.2.5/migration/migration.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/migration/migration.c	2024-06-12 21:43:13.393221456 +0300
+@@ -476,7 +476,7 @@
+         QAPI_LIST_APPEND(tail, g_strdup(exec_get_cmd_path()));
+         QAPI_LIST_APPEND(tail, g_strdup("/c"));
+ #else
+-        QAPI_LIST_APPEND(tail, g_strdup("/bin/sh"));
++        QAPI_LIST_APPEND(tail, g_strdup("@TERMUX_PREFIX@/bin/sh"));
+         QAPI_LIST_APPEND(tail, g_strdup("-c"));
+ #endif
+         QAPI_LIST_APPEND(tail, g_strdup(uri + strlen("exec:")));
+diff -uNr qemu-8.2.5/net/tap.c qemu-8.2.5.mod/net/tap.c
+--- qemu-8.2.5/net/tap.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/net/tap.c	2024-06-12 21:43:13.393221456 +0300
+@@ -578,7 +578,7 @@
+             *parg++ = helper_cmd;
+             *parg++ = NULL;
+ 
+-            execv("/bin/sh", args);
++            execv("@TERMUX_PREFIX@/bin/sh", args);
+             g_free(helper_cmd);
+         } else {
+             /* assume helper is just the executable path name */
+diff -uNr qemu-8.2.5/qemu-io.c qemu-8.2.5.mod/qemu-io.c
+--- qemu-8.2.5/qemu-io.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/qemu-io.c	2024-06-12 21:43:13.393221456 +0300
+@@ -124,7 +124,7 @@
+ " opens a new file in the requested mode\n"
+ "\n"
+ " Example:\n"
+-" 'open -n -o driver=raw /tmp/data' - opens raw data file read-write, uncached\n"
++" 'open -n -o driver=raw @TERMUX_PREFIX@/tmp/data' - opens raw data file read-write, uncached\n"
+ "\n"
+ " Opens a file for subsequent use by all of the other qemu-io commands.\n"
+ " -r, -- open file read-only\n"
+diff -uNr qemu-8.2.5/qemu-nbd.c qemu-8.2.5.mod/qemu-nbd.c
+--- qemu-8.2.5/qemu-nbd.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/qemu-nbd.c	2024-06-12 21:43:13.393221456 +0300
+@@ -57,7 +57,7 @@
+ #define HAVE_NBD_DEVICE 0
+ #endif
+ 
+-#define SOCKET_PATH                  "/var/lock/qemu-nbd-%s"
++#define SOCKET_PATH                  "@TERMUX_PREFIX@/var/lock/qemu-nbd-%s"
+ #define QEMU_NBD_OPT_CACHE           256
+ #define QEMU_NBD_OPT_AIO             257
+ #define QEMU_NBD_OPT_DISCARD         258
+@@ -95,7 +94,7 @@
+ "  -p, --port=PORT           port to listen on (default `%d')\n"
+ "  -b, --bind=IFACE          interface to bind to (default `0.0.0.0')\n"
+ "  -k, --socket=PATH         path to the unix socket\n"
+-"                            (default '"SOCKET_PATH"')\n"
++"                            (default '@TERMUX_PREFIX@/tmp/nbd-%s')\n"
+ "  -e, --shared=NUM          device can be shared by NUM clients (default '1')\n"
+ "  -t, --persistent          don't exit on the last connection\n"
+ "  -v, --verbose             display extra debugging information\n"
+@@ -1032,7 +1031,7 @@
+ 
+     if (opts.device != NULL && sockpath == NULL) {
+         sockpath = g_malloc(128);
+-        snprintf(sockpath, 128, SOCKET_PATH, basename(opts.device));
++        snprintf(sockpath, 128, "@TERMUX_PREFIX@/tmp/nbd-%s", basename(opts.device));
+     }
+ 
+     server = qio_net_listener_new();
+diff -uNr qemu-8.2.5/util/module.c qemu-8.2.5.mod/util/module.c
+--- qemu-8.2.5/util/module.c	2024-06-10 20:19:06.000000000 +0300
++++ qemu-8.2.5.mod/util/module.c	2024-06-12 21:43:13.393221456 +0300
+@@ -242,7 +242,7 @@
+     version_dir = g_strcanon(g_strdup(QEMU_PKGVERSION),
+                              G_CSET_A_2_Z G_CSET_a_2_z G_CSET_DIGITS "+-.~",
+                              '_');
+-    dirs[n_dirs++] = g_strdup_printf("/var/run/qemu/%s", version_dir);
++    dirs[n_dirs++] = g_strdup_printf("@TERMUX_PREFIX@/var/run/qemu/%s", version_dir);
+ #endif
+     assert(n_dirs <= ARRAY_SIZE(dirs));
+ 

--- a/tur/qemu-system-i386-10/0002-fix-soundcard.h-location.patch
+++ b/tur/qemu-system-i386-10/0002-fix-soundcard.h-location.patch
@@ -1,0 +1,12 @@
+diff -uNr qemu-4.2.0/audio/ossaudio.c qemu-4.2.0.mod/audio/ossaudio.c
+--- qemu-4.2.0/audio/ossaudio.c	2019-12-12 20:20:47.000000000 +0200
++++ qemu-4.2.0.mod/audio/ossaudio.c	2019-12-15 00:04:31.280813450 +0200
+@@ -24,7 +24,7 @@
+ 
+ #include "qemu/osdep.h"
+ #include <sys/ioctl.h>
+-#include <sys/soundcard.h>
++#include <linux/soundcard.h>
+ #include "qemu/main-loop.h"
+ #include "qemu/module.h"
+ #include "qemu/host-utils.h"

--- a/tur/qemu-system-i386-10/0003-fix-time_nsec-defs.patch
+++ b/tur/qemu-system-i386-10/0003-fix-time_nsec-defs.patch
@@ -1,0 +1,22 @@
+diff -uNr qemu-4.2.0/fsdev/9p-marshal.h qemu-4.2.0.mod/fsdev/9p-marshal.h
+--- qemu-4.2.0/fsdev/9p-marshal.h	2019-12-12 20:20:47.000000000 +0200
++++ qemu-4.2.0.mod/fsdev/9p-marshal.h	2019-12-15 00:09:59.586176320 +0200
+@@ -48,6 +48,18 @@
+     int64_t mtime_nsec;
+ } V9fsIattr;
+ 
++#ifdef st_atime_nsec
++# undef st_atime_nsec
++#endif
++
++#ifdef st_mtime_nsec
++# undef st_mtime_nsec
++#endif
++
++#ifdef st_ctime_nsec
++# undef st_ctime_nsec
++#endif
++
+ typedef struct V9fsStatDotl {
+     uint64_t st_result_mask;
+     V9fsQID qid;

--- a/tur/qemu-system-i386-10/0004-add-missing-telldir-seekdir.patch
+++ b/tur/qemu-system-i386-10/0004-add-missing-telldir-seekdir.patch
@@ -1,0 +1,37 @@
+diff -uNr qemu-4.2.0/hw/9pfs/9p-local.c qemu-4.2.0.mod/hw/9pfs/9p-local.c
+--- qemu-4.2.0/hw/9pfs/9p-local.c	2019-12-12 20:20:47.000000000 +0200
++++ qemu-4.2.0.mod/hw/9pfs/9p-local.c	2019-12-15 00:12:11.073725293 +0200
+@@ -535,9 +535,23 @@
+     rewinddir(fs->dir.stream);
+ }
+ 
++struct DIR {
++    int fd_;
++};
++
++static long android_telldir(struct DIR *dirp)
++{
++    return (long) lseek(dirp->fd_, 0, SEEK_CUR);
++}
++
++static void android_seekdir(DIR *dirp, long loc)
++{
++    (void) lseek(dirp->fd_, loc, SEEK_SET);
++}
++
+ static off_t local_telldir(FsContext *ctx, V9fsFidOpenState *fs)
+ {
+-    return telldir(fs->dir.stream);
++    return android_telldir(fs->dir.stream);
+ }
+ 
+ static bool local_is_mapped_file_metadata(FsContext *fs_ctx, const char *name)
+@@ -571,7 +585,7 @@
+ 
+ static void local_seekdir(FsContext *ctx, V9fsFidOpenState *fs, off_t off)
+ {
+-    seekdir(fs->dir.stream, off);
++    android_seekdir(fs->dir.stream, off);
+ }
+ 
+ static ssize_t local_preadv(FsContext *ctx, V9fsFidOpenState *fs,

--- a/tur/qemu-system-i386-10/0005-add-missing-sigorset.patch
+++ b/tur/qemu-system-i386-10/0005-add-missing-sigorset.patch
@@ -1,0 +1,31 @@
+diff -uNr qemu-4.2.0/linux-user/signal.c qemu-4.2.0.mod/linux-user/signal.c
+--- qemu-4.2.0/linux-user/signal.c	2019-12-12 20:20:48.000000000 +0200
++++ qemu-4.2.0.mod/linux-user/signal.c	2019-12-15 00:15:27.954549467 +0200
+@@ -182,6 +182,27 @@
+     return atomic_xchg(&ts->signal_pending, 1);
+ }
+ 
++#ifdef _NSIG_WORDS
++static int sigorset(sigset_t *dest, const sigset_t *a, const sigset_t *b)
++{
++    int i;
++    if (!dest || !a || !b)
++        return -1;
++    for (i = 0; i < _NSIG_WORDS; i++)
++        dest->sig[i] = a->sig[i] | b->sig[i];
++    return 0;
++}
++#else
++static int sigorset(sigset_t *dest, const sigset_t *a, const sigset_t *b)
++{
++    int i;
++    if (!dest || !a || !b)
++        return -1;
++    *dest = *a | *b;
++    return 0;
++}
++#endif
++
+ /* Wrapper for sigprocmask function
+  * Emulates a sigprocmask in a safe way for the guest. Note that set and oldset
+  * are host signal set, not guest ones. Returns -TARGET_ERESTARTSYS if

--- a/tur/qemu-system-i386-10/0006-fix-sem.h-location.patch
+++ b/tur/qemu-system-i386-10/0006-fix-sem.h-location.patch
@@ -1,0 +1,12 @@
+diff -uNr qemu-4.2.0/linux-user/strace.c qemu-4.2.0.mod/linux-user/strace.c
+--- qemu-4.2.0/linux-user/strace.c	2019-12-12 20:20:48.000000000 +0200
++++ qemu-4.2.0.mod/linux-user/strace.c	2019-12-15 00:18:22.178280369 +0200
+@@ -1,7 +1,7 @@
+ #include "qemu/osdep.h"
+ #include <sys/ipc.h>
+ #include <sys/msg.h>
+-#include <sys/sem.h>
++#include <linux/sem.h>
+ #include <sys/shm.h>
+ #include <sys/select.h>
+ #include <sys/mount.h>

--- a/tur/qemu-system-i386-10/0007-fix-syscalls.patch
+++ b/tur/qemu-system-i386-10/0007-fix-syscalls.patch
@@ -1,0 +1,239 @@
+diff -uNr qemu-8.2.0/linux-user/elfload.c qemu-8.2.0.mod/linux-user/elfload.c
+--- qemu-8.2.0/linux-user/elfload.c	2023-12-19 23:24:34.000000000 +0200
++++ qemu-8.2.0.mod/linux-user/elfload.c	2024-06-12 18:12:21.007126338 +0300
+@@ -3096,7 +3096,7 @@ void probe_guest_base(const char *image_name, abi_ulong guest_loaddr,
+                       abi_ulong guest_hiaddr)
+ {
+     /* In order to use host shmat, we must be able to honor SHMLBA.  */
+-    uintptr_t align = MAX(SHMLBA, TARGET_PAGE_SIZE);
++    uintptr_t align = MAX(/* SHMLBA */ getpagesize(), TARGET_PAGE_SIZE);
+ 
+     /* Sanity check the guest binary. */
+     if (reserved_va) {
+diff -uNr qemu-8.2.0/linux-user/mmap.c qemu-8.2.0.mod/linux-user/mmap.c
+--- qemu-8.2.0/linux-user/mmap.c	2024-06-12 18:21:01.768575000 +0300
++++ qemu-8.2.0.mod/linux-user/mmap.c	2024-06-12 18:21:30.340658216 +0300
+@@ -1310,7 +1310,7 @@ abi_ulong target_shmat(CPUArchState *cpu_env, int shmid,
+      */
+     t_shmlba = target_shmlba(cpu_env);
+     h_pagesize = qemu_real_host_page_size();
+-    h_shmlba = (HOST_FORCE_SHMLBA ? SHMLBA : h_pagesize);
++    h_shmlba = (HOST_FORCE_SHMLBA ? /* SHMLBA */ getpagesize() : h_pagesize);
+     m_shmlba = MAX(t_shmlba, h_shmlba);
+ 
+     if (shmaddr) {
+diff -uNr qemu-8.2.0/linux-user/syscall.c qemu-8.2.0.mod/linux-user/syscall.c
+--- qemu-8.2.0/linux-user/syscall.c	2024-06-12 18:10:51.058895969 +0300
++++ qemu-8.2.0.mod/linux-user/syscall.c	2024-06-12 18:12:21.011126348 +0300
+@@ -48,7 +48,7 @@
+ #include <poll.h>
+ #include <sys/times.h>
+ #include <sys/shm.h>
+-#include <sys/sem.h>
++#include <linux/sem.h>
+ #include <sys/statfs.h>
+ #include <utime.h>
+ #include <sys/sysinfo.h>
+@@ -87,12 +87,16 @@
+ 
+ #define termios host_termios
+ #define termios2 host_termios2
++#define ktermios host_ktermios
+ #define winsize host_winsize
+ #define termio host_termio
+ #define sgttyb host_sgttyb /* same as target */
+ #define tchars host_tchars /* same as target */
+ #define ltchars host_ltchars /* same as target */
+ 
++#undef __ASM_GENERIC_TERMBITS_H
++#include <asm/termbits.h>
++
+ #include <linux/termios.h>
+ #include <linux/unistd.h>
+ #include <linux/cdrom.h>
+@@ -285,6 +290,59 @@
+ #define __NR__llseek __NR_lseek
+ #endif
+ 
++_syscall0(int, vhangup)
++#ifdef __NR_msgctl
++_syscall3(int, msgctl, int, msqid, int, cmd, struct msqid_ds *, buf)
++#else
++static int
++msgctl (int msqid, int cmd, struct msqid_ds *buf)
++{
++    return syscall (__NR_ipc, IPCOP_msgctl, msqid, cmd | 0x100, 0, buf);
++}
++#endif
++
++#ifdef __NR_semget
++_syscall3(int, semget, key_t, key, int, nsems, int, semflg)
++#else
++static int
++semget (key_t key, int nsems, int semflg)
++{
++    return syscall (__NR_ipc, IPCOP_semget, key, nsems, semflg, NULL);
++}
++#endif
++
++_syscall2(int, setdomainname, const char *, name, size_t, len)
++#ifdef __NR_msgget
++_syscall2(int, msgget, key_t, key, int, msgflg)
++#else
++static int
++msgget (key_t key, int msgflg)
++{
++    return syscall(__NR_ipc, 5, IPCOP_msgget, key, msgflg, 0, NULL);
++}
++#endif
++
++#ifdef _NSIG_WORDS
++static int sigorset(sigset_t *dest, const sigset_t *a, const sigset_t *b)
++{
++    int i;
++    if (!dest || !a || !b)
++        return -1;
++    for (i = 0; i < _NSIG_WORDS; i++)
++        dest->sig[i] = a->sig[i] | b->sig[i];
++    return 0;
++}
++#else
++static int sigorset(sigset_t *dest, const sigset_t *a, const sigset_t *b)
++{
++    int i;
++    if (!dest || !a || !b)
++        return -1;
++    *dest = *a | *b;
++    return 0;
++}
++#endif
++
+ /* Newer kernel ports have llseek() instead of _llseek() */
+ #if defined(TARGET_NR_llseek) && !defined(TARGET_NR__llseek)
+ #define TARGET_NR__llseek TARGET_NR_llseek
+@@ -746,6 +804,9 @@
+     defined(TARGET_NR_mq_timedreceive_time64)
+ safe_syscall5(int, mq_timedreceive, int, mqdes, char *, msg_ptr,
+               size_t, len, unsigned *, prio, const struct timespec *, timeout)
++_syscall1(int, mq_unlink, const char *, name)
++_syscall4(__kernel_mqd_t, mq_open, const char *, name, int, oflag, mode_t, mode,
++          struct mq_attr *, attr)
+ #endif
+ #if defined(TARGET_NR_copy_file_range) && defined(__NR_copy_file_range)
+ safe_syscall6(ssize_t, copy_file_range, int, infd, loff_t *, pinoff,
+@@ -1247,7 +1308,7 @@
+ #endif
+ 
+ #if defined(TARGET_NR_mq_open) && defined(__NR_mq_open)
+-#include <mqueue.h>
++#include <linux/mqueue.h>
+ 
+ static inline abi_long copy_from_user_mq_attr(struct mq_attr *attr,
+                                               abi_ulong target_mq_attr_addr)
+@@ -3800,6 +3861,8 @@
+     return 0;
+ }
+ 
++#define semid_ds __kernel_legacy_semid_ds
++
+ static inline abi_long target_to_host_semid_ds(struct semid_ds *host_sd,
+                                                abi_ulong target_addr)
+ {
+@@ -3879,6 +3942,16 @@
+ 	abi_ulong __buf;
+ };
+ 
++#ifdef __NR_semctl
++_syscall4(int, semctl, int, semid, int, semnum, int, cmd, union semun, arg4)
++#else
++static int semctl(int semid, int semnum, int cmd, union semun arg4)
++{
++    return syscall(__NR_ipc, IPCOP_semctl, semid, semnum, cmd | 0x100,
++          arg4.__buf);
++}
++#endif
++
+ static inline abi_long target_to_host_semarray(int semid, unsigned short **host_array,
+                                                abi_ulong target_addr)
+ {
+@@ -4009,7 +4082,7 @@
+ 	case GETPID:
+ 	case GETNCNT:
+ 	case GETZCNT:
+-            ret = get_errno(semctl(semid, semnum, cmd, NULL));
++            ret = get_errno(semctl(semid, semnum, cmd, (union semun) {.buf = NULL}));
+             break;
+     }
+ 
+@@ -4144,7 +4217,7 @@
+     host_md->msg_stime = tswapal(target_md->msg_stime);
+     host_md->msg_rtime = tswapal(target_md->msg_rtime);
+     host_md->msg_ctime = tswapal(target_md->msg_ctime);
+-    host_md->__msg_cbytes = tswapal(target_md->__msg_cbytes);
++    host_md->msg_cbytes = tswapal(target_md->__msg_cbytes);
+     host_md->msg_qnum = tswapal(target_md->msg_qnum);
+     host_md->msg_qbytes = tswapal(target_md->msg_qbytes);
+     host_md->msg_lspid = tswapal(target_md->msg_lspid);
+@@ -4165,7 +4238,7 @@
+     target_md->msg_stime = tswapal(host_md->msg_stime);
+     target_md->msg_rtime = tswapal(host_md->msg_rtime);
+     target_md->msg_ctime = tswapal(host_md->msg_ctime);
+-    target_md->__msg_cbytes = tswapal(host_md->__msg_cbytes);
++    target_md->__msg_cbytes = tswapal(host_md->msg_cbytes);
+     target_md->msg_qnum = tswapal(host_md->msg_qnum);
+     target_md->msg_qbytes = tswapal(host_md->msg_qbytes);
+     target_md->msg_lspid = tswapal(host_md->msg_lspid);
+@@ -5558,6 +5631,9 @@
+     return get_errno(safe_ioctl(fd, ie->host_cmd, filter));
+ }
+ 
++#undef winsize
++#undef termio
++
+ IOCTLEntry ioctl_entries[] = {
+ #define IOCTL(cmd, access, ...) \
+     { TARGET_ ## cmd, cmd, #cmd, access, 0, {  __VA_ARGS__ } },
+@@ -9405,7 +9481,7 @@
+             return ret;
+         }
+ #endif
+-#ifdef TARGET_NR_stime /* not on alpha */
++#if 0 //def TARGET_NR_stime /* not on alpha */
+     case TARGET_NR_stime:
+         {
+             struct timespec ts;
+@@ -9469,7 +9545,7 @@
+         }
+         return ret;
+ #endif
+-#if defined(TARGET_NR_futimesat)
++#if 0 && defined(TARGET_NR_futimesat)
+     case TARGET_NR_futimesat:
+         {
+             struct timeval *tvp, tv[2];
+@@ -9513,7 +9589,7 @@
+         if (!(p = lock_user_string(arg2))) {
+             return -TARGET_EFAULT;
+         }
+-        ret = get_errno(faccessat(arg1, p, arg3, arg4));
++        ret = get_errno(faccessat(arg1, p, arg3, 0)); // https://github.com/termux/proot/discussions/291
+         unlock_user(p, arg2, 0);
+         return ret;
+ #endif
+@@ -12921,7 +12997,7 @@
+     /* Not implemented for now... */
+ /*     case TARGET_NR_mq_notify: */
+ /*         break; */
+-
++#if 0
+     case TARGET_NR_mq_getsetattr:
+         {
+             struct mq_attr posix_mq_attr_in, posix_mq_attr_out;
+@@ -12939,6 +13015,7 @@
+         }
+         return ret;
+ #endif
++#endif
+ 
+ #ifdef CONFIG_SPLICE
+ #ifdef TARGET_NR_tee

--- a/tur/qemu-system-i386-10/0008-fix-struct-member-conflicts.patch
+++ b/tur/qemu-system-i386-10/0008-fix-struct-member-conflicts.patch
@@ -1,0 +1,243 @@
+diff -uNr qemu-8.2.0/linux-user/aarch64/signal.c qemu-8.2.0.mod/linux-user/aarch64/signal.c
+--- qemu-8.2.0/linux-user/aarch64/signal.c	2023-12-19 23:24:34.000000000 +0200
++++ qemu-8.2.0.mod/linux-user/aarch64/signal.c	2024-06-12 21:15:01.494536215 +0300
+@@ -40,7 +40,7 @@
+     target_stack_t tuc_stack;
+     target_sigset_t tuc_sigmask;
+     /* glibc uses a 1024-bit sigset_t */
+-    char __unused[1024 / 8 - sizeof(target_sigset_t)];
++    char __qemu_unused[1024 / 8 - sizeof(target_sigset_t)];
+     /* last for future expansion */
+     struct target_sigcontext tuc_mcontext;
+ };
+diff -uNr qemu-8.2.0/linux-user/arm/signal.c qemu-8.2.0.mod/linux-user/arm/signal.c
+--- qemu-8.2.0/linux-user/arm/signal.c	2023-12-19 23:24:34.000000000 +0200
++++ qemu-8.2.0.mod/linux-user/arm/signal.c	2024-06-12 21:15:01.494536215 +0300
+@@ -54,7 +54,7 @@
+     target_stack_t tuc_stack;
+     struct target_sigcontext tuc_mcontext;
+     target_sigset_t  tuc_sigmask;       /* mask last for extensibility */
+-    char __unused[128 - sizeof(target_sigset_t)];
++    char __qemu_unused[128 - sizeof(target_sigset_t)];
+     abi_ulong tuc_regspace[128] __attribute__((__aligned__(8)));
+ };
+ 
+diff -uNr qemu-8.2.0/linux-user/riscv/signal.c qemu-8.2.0.mod/linux-user/riscv/signal.c
+--- qemu-8.2.0/linux-user/riscv/signal.c	2023-12-19 23:24:34.000000000 +0200
++++ qemu-8.2.0.mod/linux-user/riscv/signal.c	2024-06-12 21:15:01.494536215 +0300
+@@ -45,7 +45,7 @@
+     abi_ptr uc_link;
+     target_stack_t uc_stack;
+     target_sigset_t uc_sigmask;
+-    uint8_t   __unused[1024 / 8 - sizeof(target_sigset_t)];
++    uint8_t   __qemu_unused[1024 / 8 - sizeof(target_sigset_t)];
+     struct target_sigcontext uc_mcontext QEMU_ALIGNED(16);
+ };
+ 
+diff -uNr qemu-8.2.0/linux-user/syscall_defs.h qemu-8.2.0.mod/linux-user/syscall_defs.h
+--- qemu-8.2.0/linux-user/syscall_defs.h	2023-12-19 23:24:34.000000000 +0200
++++ qemu-8.2.0.mod/linux-user/syscall_defs.h	2024-06-12 21:15:23.174821140 +0300
+@@ -1252,8 +1252,8 @@
+     abi_ulong  target_st_mtime_nsec;
+     abi_ulong  target_st_ctime;
+     abi_ulong  target_st_ctime_nsec;
+-    abi_ulong  __unused4;
+-    abi_ulong  __unused5;
++    abi_ulong  __qemu_unused4;
++    abi_ulong  __qemu_unused5;
+ };
+ 
+ /* This matches struct stat64 in glibc2.1, hence the absolutely
+@@ -1342,7 +1342,7 @@
+     abi_long        target_st_ctime;
+     abi_long        st_blksize;
+     abi_long        st_blocks;
+-    abi_ulong       __unused4[2];
++    abi_ulong       __qemu_unused4[2];
+ };
+ 
+ #define TARGET_HAS_STRUCT_STAT64
+@@ -1376,7 +1376,7 @@
+     abi_ulong       target_st_ctime;
+     abi_ulong       target_st_ctime_nsec;
+ 
+-    abi_ulong       __unused4[3];
++    abi_ulong       __qemu_unused4[3];
+ };
+ 
+ #elif defined(TARGET_SPARC)
+@@ -1399,7 +1399,7 @@
+     abi_ulong       target_st_ctime_nsec;
+     abi_long        st_blksize;
+     abi_long        st_blocks;
+-    abi_ulong       __unused1[2];
++    abi_ulong       __qemu_unused1[2];
+ };
+ 
+ #define TARGET_HAS_STRUCT_STAT64
+@@ -1435,8 +1435,8 @@
+     abi_uint        target_st_ctime;
+     abi_uint        target_st_ctime_nsec;
+ 
+-    abi_uint        __unused1;
+-    abi_uint        __unused2;
++    abi_uint        __qemu_unused1;
++    abi_uint        __qemu_unused2;
+ };
+ 
+ #elif defined(TARGET_PPC)
+@@ -1464,10 +1464,10 @@
+     abi_ulong  target_st_mtime_nsec;
+     abi_ulong  target_st_ctime;
+     abi_ulong  target_st_ctime_nsec;
+-    abi_ulong  __unused4;
+-    abi_ulong  __unused5;
++    abi_ulong  __qemu_unused4;
++    abi_ulong  __qemu_unused5;
+ #if defined(TARGET_PPC64)
+-    abi_ulong  __unused6;
++    abi_ulong  __qemu_unused6;
+ #endif
+ };
+ 
+@@ -1492,8 +1492,8 @@
+     abi_uint       target_st_mtime_nsec;
+     abi_int        target_st_ctime;
+     abi_uint       target_st_ctime_nsec;
+-    abi_uint       __unused4;
+-    abi_uint       __unused5;
++    abi_uint       __qemu_unused4;
++    abi_uint       __qemu_unused5;
+ };
+ #endif
+ 
+@@ -1517,8 +1517,8 @@
+     abi_ulong  target_st_mtime_nsec;
+     abi_ulong  target_st_ctime;
+     abi_ulong  target_st_ctime_nsec;
+-    abi_ulong  __unused4;
+-    abi_ulong  __unused5;
++    abi_ulong  __qemu_unused4;
++    abi_ulong  __qemu_unused5;
+ };
+ 
+ /* FIXME: Microblaze no-mmu user-space has a difference stat64 layout...  */
+@@ -1566,13 +1566,13 @@
+     abi_ulong  st_blksize;
+     abi_ulong  st_blocks;
+     abi_ulong  target_st_atime;
+-    abi_ulong  __unused1;
++    abi_ulong  __qemu_unused1;
+     abi_ulong  target_st_mtime;
+-    abi_ulong  __unused2;
++    abi_ulong  __qemu_unused2;
+     abi_ulong  target_st_ctime;
+-    abi_ulong  __unused3;
+-    abi_ulong  __unused4;
+-    abi_ulong  __unused5;
++    abi_ulong  __qemu_unused3;
++    abi_ulong  __qemu_unused4;
++    abi_ulong  __qemu_unused5;
+ };
+ 
+ /* This matches struct stat64 in glibc2.1, hence the absolutely
+@@ -1792,7 +1792,7 @@
+     abi_ulong    target_st_mtime_nsec;
+     abi_ulong    target_st_ctime;
+     abi_ulong    target_st_ctime_nsec;
+-    abi_long     __unused[3];
++    abi_long     __qemu_unused[3];
+ };
+ 
+ #elif defined(TARGET_SH4)
+@@ -1815,8 +1815,8 @@
+     abi_ulong  target_st_mtime_nsec;
+     abi_ulong  target_st_ctime;
+     abi_ulong  target_st_ctime_nsec;
+-    abi_ulong  __unused4;
+-    abi_ulong  __unused5;
++    abi_ulong  __qemu_unused4;
++    abi_ulong  __qemu_unused5;
+ };
+ 
+ /* This matches struct stat64 in glibc2.1, hence the absolutely
+@@ -1879,7 +1879,7 @@
+     abi_ulong       target_st_ctime;
+     abi_ulong       target_st_ctime_nsec;
+ 
+-    abi_long        __unused[3];
++    abi_long        __qemu_unused[3];
+ };
+ #elif defined(TARGET_S390X)
+ struct target_stat {
+@@ -1900,7 +1900,7 @@
+     abi_ulong  target_st_ctime_nsec;
+     abi_ulong  st_blksize;
+     abi_long       st_blocks;
+-    abi_ulong  __unused[3];
++    abi_ulong  __qemu_unused[3];
+ };
+ #elif defined(TARGET_AARCH64)
+ #define TARGET_STAT_HAVE_NSEC
+@@ -1923,7 +1923,7 @@
+     abi_ulong  target_st_mtime_nsec;
+     abi_long  target_st_ctime;
+     abi_ulong  target_st_ctime_nsec;
+-    abi_uint __unused[2];
++    abi_uint __qemu_unused[2];
+ };
+ #elif defined(TARGET_XTENSA)
+ #define TARGET_STAT_HAVE_NSEC
+@@ -1944,8 +1944,8 @@
+     abi_ulong       target_st_mtime_nsec;
+     abi_ulong       target_st_ctime;
+     abi_ulong       target_st_ctime_nsec;
+-    abi_ulong       __unused4;
+-    abi_ulong       __unused5;
++    abi_ulong       __qemu_unused4;
++    abi_ulong       __qemu_unused5;
+ };
+ 
+ #define TARGET_HAS_STRUCT_STAT64
+@@ -1959,7 +1959,7 @@
+     abi_ullong st_rdev;         /* Device number, if device. */
+     abi_llong st_size;          /* Size of file, in bytes. */
+     abi_ulong st_blksize;       /* Optimal block size for I/O. */
+-    abi_ulong __unused2;
++    abi_ulong __qemu_unused2;
+     abi_ullong st_blocks;       /* Number 512-byte blocks allocated. */
+     abi_ulong target_st_atime;  /* Time of last access. */
+     abi_ulong target_st_atime_nsec;
+@@ -1967,8 +1967,8 @@
+     abi_ulong target_st_mtime_nsec;
+     abi_ulong target_st_ctime;  /* Time of last status change. */
+     abi_ulong target_st_ctime_nsec;
+-    abi_ulong __unused4;
+-    abi_ulong __unused5;
++    abi_ulong __qemu_unused4;
++    abi_ulong __qemu_unused5;
+ };
+ 
+ #elif defined(TARGET_OPENRISC) || defined(TARGET_NIOS2) \
+@@ -1996,8 +1996,8 @@
+     abi_ulong target_st_mtime_nsec;
+     abi_long target_st_ctime;
+     abi_ulong target_st_ctime_nsec;
+-    abi_uint __unused4;
+-    abi_uint __unused5;
++    abi_uint __qemu_unused4;
++    abi_uint __qemu_unused5;
+ };
+ 
+ #if !defined(TARGET_RISCV64)
+@@ -2021,8 +2021,8 @@
+     abi_uint target_st_mtime_nsec;
+     abi_int target_st_ctime;
+     abi_uint target_st_ctime_nsec;
+-    abi_uint __unused4;
+-    abi_uint __unused5;
++    abi_uint __qemu_unused4;
++    abi_uint __qemu_unused5;
+ };
+ #endif
+ 

--- a/tur/qemu-system-i386-10/0009-disable-glob.h-include.patch
+++ b/tur/qemu-system-i386-10/0009-disable-glob.h-include.patch
@@ -1,0 +1,11 @@
+diff -uNr qemu-4.2.0/util/drm.c qemu-4.2.0.mod/util/drm.c
+--- qemu-4.2.0/util/drm.c	2019-12-12 20:20:48.000000000 +0200
++++ qemu-4.2.0.mod/util/drm.c	2019-12-15 02:18:23.537494928 +0200
+@@ -17,7 +17,6 @@
+ #include "qemu/osdep.h"
+ #include "qemu/drm.h"
+ 
+-#include <glob.h>
+ #include <dirent.h>
+ 
+ int qemu_drm_rendernode_open(const char *rendernode)

--- a/tur/qemu-system-i386-10/0010-add-missing-arch_prctl.patch
+++ b/tur/qemu-system-i386-10/0010-add-missing-arch_prctl.patch
@@ -1,0 +1,16 @@
+diff -uNr qemu-8.2.5/tcg/i386/tcg-target.c.inc qemu-8.2.5.mod/tcg/i386/tcg-target.c.inc
+--- qemu-8.2.5/tcg/i386/tcg-target.c.inc	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/tcg/i386/tcg-target.c.inc	2024-06-12 23:46:41.377731268 +0300
+@@ -1938,7 +1938,11 @@
+ #if defined(__x86_64__) && defined(__linux__)
+ # include <asm/prctl.h>
+ # include <sys/prctl.h>
+-int arch_prctl(int code, unsigned long addr);
++# include <linux/unistd.h>
++static int arch_prctl(int code, unsigned long addr)
++{
++    return syscall(__NR_arch_prctl, code, addr);
++}
+ static inline int setup_guest_base_seg(void)
+ {
+     if (arch_prctl(ARCH_SET_GS, guest_base) == 0) {

--- a/tur/qemu-system-i386-10/0011-mmap_min_addr-fallback.patch
+++ b/tur/qemu-system-i386-10/0011-mmap_min_addr-fallback.patch
@@ -1,0 +1,17 @@
+diff -uNr qemu-5.2.0/linux-user/main.c qemu-5.2.0.mod/linux-user/main.c
+--- qemu-5.2.0/linux-user/main.c	2020-12-08 18:59:44.000000000 +0200
++++ qemu-5.2.0.mod/linux-user/main.c	2020-12-24 17:41:07.982481916 +0200
+@@ -770,7 +770,13 @@
+      * If we're in a chroot with no /proc, fall back to 1 page.
+      */
+     if (mmap_min_addr == 0) {
++#ifdef __ANDROID__
++        // Go with 8 pages (32768 bytes) as default value for Android (Termux).
++        // Issue https://github.com/termux/termux-packages/issues/6172.
++        mmap_min_addr = host_page_size * 8;
++#else
+         mmap_min_addr = host_page_size;
++#endif
+         qemu_log_mask(CPU_LOG_PAGE,
+                       "host mmap_min_addr=0x%lx (fallback)\n",
+                       mmap_min_addr);

--- a/tur/qemu-system-i386-10/0012-force-ucs2-little-endian.patch
+++ b/tur/qemu-system-i386-10/0012-force-ucs2-little-endian.patch
@@ -1,0 +1,20 @@
+diff -uNr qemu-5.2.0/ui/curses.c qemu-5.2.0.mod/ui/curses.c
+--- qemu-5.2.0/ui/curses.c	2020-12-08 18:59:44.000000000 +0200
++++ qemu-5.2.0.mod/ui/curses.c	2021-01-30 01:29:40.987065827 +0200
+@@ -566,14 +566,14 @@
+       0x25bc
+     };
+ 
+-    ucs2_to_nativecharset = iconv_open(local_codeset, "UCS-2");
++    ucs2_to_nativecharset = iconv_open(local_codeset, "UCS-2LE");
+     if (ucs2_to_nativecharset == (iconv_t) -1) {
+         fprintf(stderr, "Could not convert font glyphs from UCS-2: '%s'\n",
+                         strerror(errno));
+         exit(1);
+     }
+ 
+-    nativecharset_to_ucs2 = iconv_open("UCS-2", local_codeset);
++    nativecharset_to_ucs2 = iconv_open("UCS-2LE", local_codeset);
+     if (nativecharset_to_ucs2 == (iconv_t) -1) {
+         iconv_close(ucs2_to_nativecharset);
+         fprintf(stderr, "Could not convert font glyphs to UCS-2: '%s'\n",

--- a/tur/qemu-system-i386-10/0013-9pfs-dont-chmod-mapfile.patch
+++ b/tur/qemu-system-i386-10/0013-9pfs-dont-chmod-mapfile.patch
@@ -1,0 +1,12 @@
+diff -uNr qemu-5.2.0/hw/9pfs/9p-local.c qemu-5.2.0.mod/hw/9pfs/9p-local.c
+--- qemu-5.2.0/hw/9pfs/9p-local.c	2020-12-08 18:59:44.000000000 +0200
++++ qemu-5.2.0.mod/hw/9pfs/9p-local.c	2021-08-07 17:01:43.567841976 +0300
+@@ -299,8 +299,6 @@
+ 
+     map_fd = fileno(fp);
+     assert(map_fd != -1);
+-    ret = fchmod(map_fd, 0600);
+-    assert(ret == 0);
+ 
+     if (credp->fc_uid != -1) {
+         uid = credp->fc_uid;

--- a/tur/qemu-system-i386-10/0014-disable-signalfd.patch
+++ b/tur/qemu-system-i386-10/0014-disable-signalfd.patch
@@ -1,0 +1,13 @@
+diff -uNr qemu-6.1.0/meson.build qemu-6.1.0.mod/meson.build
+--- qemu-6.1.0/meson.build	2021-08-25 21:20:39.873631512 +0300
++++ qemu-6.1.0.mod/meson.build	2021-08-25 21:21:35.135670419 +0300
+@@ -2948,9 +2948,6 @@ config_host_data.set('CONFIG_PTHREAD_AFFINITY_NP', cc.links(osdep_prefix + '''
+     CPU_FREE(cpuset);
+     return 0;
+   }''', dependencies: threads))
+-config_host_data.set('CONFIG_SIGNALFD', cc.links(osdep_prefix + '''
+-  #include <sys/signalfd.h>
+-  int main(void) { return signalfd(-1, NULL, SFD_CLOEXEC); }'''))
+ config_host_data.set('CONFIG_SPLICE', cc.links(osdep_prefix + '''
+   int main(void)
+   {

--- a/tur/qemu-system-i386-10/0015-workaround-android-ndk-patch.patch
+++ b/tur/qemu-system-i386-10/0015-workaround-android-ndk-patch.patch
@@ -1,0 +1,18 @@
+Termux sets AT_EACCESS as 0, see ../../ndk-patches/*/linux-fcntl.h.patch.
+This is not allowed in macros FLAG_GENERIC and cause compilation failure.
+
+Although Android doesn't support AT_EACCESS, using its original value here
+shouldn't cause runtime issues.
+
+diff -uNr qemu-8.2.5/linux-user/strace.c qemu-8.2.5.mod/linux-user/strace.c
+--- qemu-8.2.5/linux-user/strace.c	2024-06-10 20:19:05.000000000 +0300
++++ qemu-8.2.5.mod/linux-user/strace.c	2024-06-12 22:41:27.640567571 +0300
+@@ -977,7 +977,7 @@
+ 
+ UNUSED static const struct flags at_file_flags[] = {
+ #ifdef AT_EACCESS
+-    FLAG_GENERIC(AT_EACCESS),
++    FLAG_GENERIC(/* AT_EACCESS */ 0x200),
+ #endif
+ #ifdef AT_SYMLINK_NOFOLLOW
+     FLAG_GENERIC(AT_SYMLINK_NOFOLLOW),

--- a/tur/qemu-system-i386-10/0016-Add-workaround-for-tagged-pointers-on-Android-12.patch
+++ b/tur/qemu-system-i386-10/0016-Add-workaround-for-tagged-pointers-on-Android-12.patch
@@ -1,0 +1,63 @@
+From 8614247167fe7e628836af9b87c4355881e0b1bf Mon Sep 17 00:00:00 2001
+From: Rhys-T <108157737+Rhys-T@users.noreply.github.com>
+Date: Mon, 17 Mar 2025 15:06:05 -0400
+Subject: [PATCH] Add workaround for tagged pointers on Android 12
+
+Based on the corresponding OpenJDK patch at:
+https://github.com/termux/termux-packages/blob/3ca825e40d7cf2f456ac5d5fd7b1a1693470081d/packages/openjdk-21/0022-Add-workaround-for-tagged-pointers-on-Android-12.patch
+
+Co-authored-by: Tee KOBAYASHI <xtkoba@gmail.com>
+Co-authored-by: dev-bz <32380878+dev-bz@users.noreply.github.com>
+---
+ system/vl.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/system/vl.c b/system/vl.c
+index ec93988..0d0942a 100644
+--- a/system/vl.c
++++ b/system/vl.c
+@@ -140,6 +140,32 @@
+ #include "qemu/guest-random.h"
+ #include "qemu/keyval.h"
+ 
++#ifdef __TERMUX__
++#include <stdbool.h>
++#include <dlfcn.h>
++static void android_disable_tags() {
++    void *lib_handle = dlopen("libc.so", RTLD_LAZY);
++    if (lib_handle) {
++        if (android_get_device_api_level() >= 31) {
++            int (*mallopt_func)(int, int) = dlsym(lib_handle, "mallopt");
++            if (mallopt_func) {
++                mallopt_func(M_BIONIC_SET_HEAP_TAGGING_LEVEL, 0);
++            }
++            return;
++        }
++        /* android_get_device_api_level() < 31 */
++        bool (*android_mallopt)(int opcode, void* arg, size_t arg_size) = dlsym(lib_handle, "android_mallopt");
++        if (android_mallopt) {
++            int android_malloc_tag_level = 0;
++            android_mallopt(8, &android_malloc_tag_level, sizeof(android_malloc_tag_level));
++        }
++        dlclose(lib_handle);
++    }
++}
++#else
++static void android_disable_tags(){}
++#endif
++
+ #define MAX_VIRTIO_CONSOLES 1
+ 
+ typedef struct BlockdevOptionsQueueEntry {
+@@ -2848,6 +2874,8 @@ void qemu_init(int argc, char **argv)
+     bool userconfig = true;
+     FILE *vmstate_dump_file = NULL;
+ 
++    android_disable_tags();
++
+     qemu_add_opts(&qemu_drive_opts);
+     qemu_add_drive_opts(&qemu_legacy_drive_opts);
+     qemu_add_drive_opts(&qemu_common_drive_opts);
+-- 
+2.24.3 (Apple Git-128)
+

--- a/tur/qemu-system-i386-10/0017-shm_open.patch
+++ b/tur/qemu-system-i386-10/0017-shm_open.patch
@@ -1,0 +1,71 @@
+shm_unlink() and shm_open() implementations from other packages like qt5-qtbase:
+https://github.com/termux/termux-packages/pull/17789
+
+--- a/util/oslib-posix.c
++++ b/util/oslib-posix.c
+@@ -61,6 +61,65 @@
+ #include "qemu/memalign.h"
+ #include "qemu/mmap-alloc.h"
+ 
++static int shm_unlink(const char *name) {
++    size_t namelen;
++    char *fname;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    return unlink(fname);
++}
++
++static int shm_open(const char *name, int oflag, mode_t mode) {
++    size_t namelen;
++    char *fname;
++    int fd;
++
++    /* Construct the filename.  */
++    while (name[0] == '/') ++name;
++
++    if (name[0] == '\0') {
++        /* The name "/" is not supported.  */
++        errno = EINVAL;
++        return -1;
++    }
++
++    namelen = strlen(name);
++    fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++    memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++    memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++    fd = open(fname, oflag, mode);
++    if (fd != -1) {
++        /* We got a descriptor.  Now set the FD_CLOEXEC bit.  */
++        int flags = fcntl(fd, F_GETFD, 0);
++        flags |= FD_CLOEXEC;
++        flags = fcntl(fd, F_SETFD, flags);
++
++        if (flags == -1) {
++            /* Something went wrong.  We cannot return the descriptor.  */
++            int save_errno = errno;
++            close(fd);
++            fd = -1;
++            errno = save_errno;
++        }
++    }
++
++    return fd;
++}
++
+ #define MAX_MEM_PREALLOC_THREAD_COUNT 16
+ 
+ struct MemsetThread;

--- a/tur/qemu-system-i386-10/0018-libnfs-fix.patch
+++ b/tur/qemu-system-i386-10/0018-libnfs-fix.patch
@@ -1,0 +1,27 @@
+diff -uNr qemu-8.2.6/block/nfs.c qemu-8.2.6.mod/block/nfs.c
+--- qemu-8.2.6/block/nfs.c	2024-07-16 23:23:46.000000000 +0300
++++ qemu-8.2.6.mod/block/nfs.c	2024-12-22 14:30:32.265373660 +0200
+@@ -270,11 +270,11 @@
+     NFSRPC task;
+ 
+     nfs_co_init_task(bs, &task);
+-    task.iov = iov;
+ 
+     WITH_QEMU_LOCK_GUARD(&client->mutex) {
+-        if (nfs_pread_async(client->context, client->fh,
+-                            offset, bytes, nfs_co_generic_cb, &task) != 0) {
++        if (nfs_pread_async(client->context, client->fh, iov->iov[0].iov_base,
++                            bytes > iov->iov[0].iov_len ? iov->iov[0].iov_len : bytes,
++                            offset, nfs_co_generic_cb, &task) != 0) {
+             return -ENOMEM;
+         }
+ 
+@@ -320,7 +320,7 @@
+ 
+     WITH_QEMU_LOCK_GUARD(&client->mutex) {
+         if (nfs_pwrite_async(client->context, client->fh,
+-                             offset, bytes, buf,
++                             buf, bytes, offset,
+                              nfs_co_generic_cb, &task) != 0) {
+             if (my_buffer) {
+                 g_free(buf);

--- a/tur/qemu-system-i386-10/0019-no-timespec_get.patch
+++ b/tur/qemu-system-i386-10/0019-no-timespec_get.patch
@@ -1,0 +1,11 @@
+--- a/contrib/plugins/uftrace.c
++++ b/contrib/plugins/uftrace.c
+@@ -115,7 +115,7 @@ static CpuOps arch_ops;
+ 
+ static uint64_t gettime_ns(void)
+ {
+-#ifdef _WIN32
++#if defined(_WIN32) || (defined(__ANDROID__) && __ANDROID_API__ < 29)
+     /*
+      * On Windows, timespec_get is available only with UCRT, but not with
+      * MinGW64 environment. Simplify by using only gettimeofday on this

--- a/tur/qemu-system-i386-10/build.sh
+++ b/tur/qemu-system-i386-10/build.sh
@@ -1,0 +1,112 @@
+TERMUX_PKG_HOMEPAGE=https://www.qemu.org
+TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="10.2.1"
+TERMUX_PKG_SRCURL="https://download.qemu.org/qemu-${TERMUX_PKG_VERSION}.tar.xz"
+TERMUX_PKG_SHA256=a3717477d8e2c84d630bfffbc20f6cd3293eb45aa1e6dac6d0cc27689991c9e1
+TERMUX_PKG_DEPENDS="alsa-lib, dtc, gdk-pixbuf, glib, jack2, gtk3, libbz2, libcairo, libcurl, libdw, libepoxy, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, libx11, mesa, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2 | sdl2-compat, sdl2-image, virglrenderer, zlib, zstd"
+# Required by configuration script, but Leonid Pliushch couldn't find any binary that uses it.
+TERMUX_PKG_BUILD_DEPENDS="libtasn1"
+TERMUX_PKG_ANTI_BUILD_DEPENDS="sdl2-compat"
+TERMUX_SUBPKG_BREAKS="qemu-system-i386-headless, qemu-system-i386"
+TERMUX_SUBPKG_REPLACES="qemu-system-i386-headless, qemu-system-i386"
+TERMUX_SUBPKG_PROVIDES="qemu-system-i386-headless, qemu-system-i386"
+# this package is for 32-bit devices which can't run QEMU version 11 or newer.
+TERMUX_PKG_EXCLUDED_ARCHES="x86_64, aarch64"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_configure() {
+	termux_setup_ninja
+
+	if [[ "$TERMUX_ARCH" == "i686" ]]; then
+		LDFLAGS+=" -latomic"
+	fi
+
+	local QEMU_TARGETS=""
+
+	# System emulation.
+	QEMU_TARGETS+="arm-softmmu,"
+	QEMU_TARGETS+="i386-softmmu,"
+	QEMU_TARGETS+="m68k-softmmu,"
+	QEMU_TARGETS+="ppc-softmmu,"
+	QEMU_TARGETS+="riscv32-softmmu,"
+
+	# User mode emulation.
+	QEMU_TARGETS+="arm-linux-user,"
+	QEMU_TARGETS+="i386-linux-user,"
+	QEMU_TARGETS+="m68k-linux-user,"
+	QEMU_TARGETS+="ppc-linux-user,"
+	QEMU_TARGETS+="riscv32-linux-user"
+
+	CFLAGS+=" $CPPFLAGS"
+	CXXFLAGS+=" $CPPFLAGS"
+	LDFLAGS+=" -landroid-shmem -llog"
+
+	# Note: using --disable-stack-protector since stack protector
+	# flags already passed by build scripts but we do not want to
+	# override them with what QEMU configure provides.
+	./configure \
+		--prefix="$TERMUX_PREFIX" \
+		--cross-prefix="${TERMUX_HOST_PLATFORM}-" \
+		--host-cc="gcc" \
+		--cc="$CC" \
+		--cxx="$CXX" \
+		--objcc="$CC" \
+		--disable-stack-protector \
+		--smbd="$TERMUX_PREFIX/bin/smbd" \
+		--enable-coroutine-pool \
+		--audio-drv-list=pa,sdl \
+		--enable-trace-backends=nop \
+		--disable-guest-agent \
+		--enable-gnutls \
+		--enable-nettle \
+		--enable-sdl \
+		--enable-sdl-image \
+		--enable-gtk \
+		--enable-opengl \
+		--enable-virglrenderer \
+		--disable-vte \
+		--enable-curses \
+		--enable-iconv \
+		--enable-vnc \
+		--disable-vnc-sasl \
+		--enable-vnc-jpeg \
+		--enable-png \
+		--disable-xen \
+		--disable-xen-pci-passthrough \
+		--enable-virtfs \
+		--enable-curl \
+		--enable-fdt=system \
+		--enable-kvm \
+		--disable-hvf \
+		--disable-whpx \
+		--disable-libnfs \
+		--enable-lzo \
+		--disable-snappy \
+		--enable-bzip2 \
+		--disable-lzfse \
+		--disable-seccomp \
+		--enable-libssh \
+		--enable-bochs \
+		--enable-cloop \
+		--enable-dmg \
+		--enable-parallels \
+		--enable-qed \
+		--enable-slirp \
+		--enable-spice \
+		--enable-libusb \
+		--enable-usb-redir \
+		--disable-vhost-user \
+		--disable-vhost-user-blk-server \
+		--target-list="$QEMU_TARGETS"
+}
+
+termux_step_post_make_install() {
+	local i
+	for i in arm i386 m68k ppc riscv32; do
+		ln -sfr \
+			"${TERMUX_PREFIX}"/share/man/man1/qemu.1 \
+			"${TERMUX_PREFIX}"/share/man/man1/qemu-system-${i}.1
+	done
+}

--- a/tur/qemu-system-i386-10/qemu-common-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-common-10.subpackage.sh
@@ -1,0 +1,20 @@
+TERMUX_SUBPKG_DESCRIPTION="A set common files used by the QEMU emulators"
+TERMUX_SUBPKG_DEPENDS="glib, libbz2, libcap-ng, libcurl, libgmp, libgnutls, libnettle, libnfs, libpixman, libssh, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="qemu-system-x86-64 (<< 1:8.0.0), qemu-system-x86-64-headless (<< 1:8.0.0), qemu-common"
+TERMUX_SUBPKG_REPLACES="qemu-system-x86-64 (<< 1:8.0.0), qemu-system-x86-64-headless (<< 1:8.0.0), qemu-common"
+TERMUX_SUBPKG_PROVIDES="qemu-common"
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-pr-helper
+bin/qemu-storage-daemon
+include
+libexec/qemu-bridge-helper
+share/applications
+share/doc
+share/icons
+share/man/man1/qemu-storage-daemon.1.gz
+share/man/man1/qemu.1.gz
+share/man/man7
+share/man/man8
+share/qemu
+"

--- a/tur/qemu-system-i386-10/qemu-system-arm-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-system-arm-10.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
+TERMUX_SUBPKG_BREAKS="qemu-system-arm-headless, qemu-system-arm"
+TERMUX_SUBPKG_REPLACES="qemu-system-arm-headless, qemu-system-arm"
+TERMUX_SUBPKG_PROVIDES="qemu-system-arm-headless, qemu-system-arm"
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-arm
+share/man/man1/qemu-system-arm.1.gz
+"

--- a/tur/qemu-system-i386-10/qemu-system-m68k-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-system-m68k-10.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
+TERMUX_SUBPKG_BREAKS="qemu-system-m68k-headless, qemu-system-m68k"
+TERMUX_SUBPKG_REPLACES="qemu-system-m68k-headless, qemu-system-m68k"
+TERMUX_SUBPKG_PROVIDES="qemu-system-m68k-headless, qemu-system-m68k"
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-m68k
+share/man/man1/qemu-system-m68k.1.gz
+"

--- a/tur/qemu-system-i386-10/qemu-system-ppc-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-system-ppc-10.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
+TERMUX_SUBPKG_BREAKS="qemu-system-ppc-headless, qemu-system-ppc"
+TERMUX_SUBPKG_REPLACES="qemu-system-ppc-headless, qemu-system-ppc"
+TERMUX_SUBPKG_PROVIDES="qemu-system-ppc-headless, qemu-system-ppc"
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-ppc
+share/man/man1/qemu-system-ppc.1.gz
+"

--- a/tur/qemu-system-i386-10/qemu-system-riscv32-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-system-riscv32-10.subpackage.sh
@@ -1,0 +1,9 @@
+TERMUX_SUBPKG_DESCRIPTION="A generic and open source machine emulator and virtualizer (headless)"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=deps
+TERMUX_SUBPKG_BREAKS="qemu-system-riscv32-headless, qemu-system-riscv32"
+TERMUX_SUBPKG_REPLACES="qemu-system-riscv32-headless, qemu-system-riscv32"
+TERMUX_SUBPKG_PROVIDES="qemu-system-riscv32-headless, qemu-system-riscv32"
+TERMUX_SUBPKG_INCLUDE="
+bin/qemu-system-riscv32
+share/man/man1/qemu-system-riscv32.1.gz
+"

--- a/tur/qemu-system-i386-10/qemu-user-arm-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-user-arm-10.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libdw, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="qemu-user-arm"
+TERMUX_SUBPKG_REPLACES="qemu-user-arm"
+TERMUX_SUBPKG_PROVIDES="qemu-user-arm"
+TERMUX_SUBPKG_INCLUDE="bin/qemu-arm"

--- a/tur/qemu-system-i386-10/qemu-user-i386-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-user-i386-10.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libdw, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="qemu-user-i386"
+TERMUX_SUBPKG_REPLACES="qemu-user-i386"
+TERMUX_SUBPKG_PROVIDES="qemu-user-i386"
+TERMUX_SUBPKG_INCLUDE="bin/qemu-i386"

--- a/tur/qemu-system-i386-10/qemu-user-m68k-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-user-m68k-10.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libdw, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="qemu-user-m68k"
+TERMUX_SUBPKG_REPLACES="qemu-user-m68k"
+TERMUX_SUBPKG_PROVIDES="qemu-user-m68k"
+TERMUX_SUBPKG_INCLUDE="bin/qemu-m68k"

--- a/tur/qemu-system-i386-10/qemu-user-ppc-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-user-ppc-10.subpackage.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libdw, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="qemu-user-ppc"
+TERMUX_SUBPKG_REPLACES="qemu-user-ppc"
+TERMUX_SUBPKG_PROVIDES="qemu-user-ppc"
+TERMUX_SUBPKG_INCLUDE="bin/qemu-ppc"

--- a/tur/qemu-system-i386-10/qemu-user-riscv32-10.subpackage copy.sh
+++ b/tur/qemu-system-i386-10/qemu-user-riscv32-10.subpackage copy.sh
@@ -1,0 +1,7 @@
+TERMUX_SUBPKG_DESCRIPTION="QEMU Linux user mode emulator"
+TERMUX_SUBPKG_DEPENDS="glib, libandroid-shmem, libdw, libgnutls, libpixman"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="qemu-user-riscv32"
+TERMUX_SUBPKG_REPLACES="qemu-user-riscv32"
+TERMUX_SUBPKG_PROVIDES="qemu-user-riscv32"
+TERMUX_SUBPKG_INCLUDE="bin/qemu-riscv32"

--- a/tur/qemu-system-i386-10/qemu-utils-10.subpackage.sh
+++ b/tur/qemu-system-i386-10/qemu-utils-10.subpackage.sh
@@ -1,0 +1,15 @@
+TERMUX_SUBPKG_DESCRIPTION="A set of utilities for working with the QEMU emulators"
+TERMUX_SUBPKG_DEPENDS="glib, libbz2, libcurl, libgmp, libgnutls, libnettle, libnfs, libpixman, libssh, zlib, zstd"
+TERMUX_SUBPKG_DEPEND_ON_PARENT=false
+TERMUX_SUBPKG_BREAKS="qemu-utils"
+TERMUX_SUBPKG_REPLACES="qemu-utils"
+TERMUX_SUBPKG_PROVIDES="qemu-utils"
+TERMUX_SUBPKG_INCLUDE="
+bin/elf2dmp
+bin/qemu-edid
+bin/qemu-img
+bin/qemu-io
+bin/qemu-nbd
+share/man/man1/qemu-img.1.gz
+share/man/man8/qemu-nbd.8.gz
+"

--- a/tur/qemu-system-x86-64-9/build.sh
+++ b/tur/qemu-system-x86-64-9/build.sh
@@ -2,10 +2,11 @@ TERMUX_PKG_HOMEPAGE=https://www.qemu.org
 TERMUX_PKG_DESCRIPTION="A generic and open source machine emulator and virtualizer"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
-TERMUX_PKG_VERSION=9.2.4
-TERMUX_PKG_SRCURL=https://download.qemu.org/qemu-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_VERSION="9.2.4"
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL="https://download.qemu.org/qemu-${TERMUX_PKG_VERSION}.tar.xz"
 TERMUX_PKG_SHA256=f3cc1c4eabfdb288218ac3e33763dbe9e276d8bc890b867a2335d58de2ddd39a
-TERMUX_PKG_DEPENDS="alsa-lib, dtc, gdk-pixbuf, glib, jack2, gtk3, libbz2, libcairo, libcurl, libdw, libepoxy, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, libx11, mesa, ncurses, pulseaudio, qemu-common, resolv-conf, sdl2 | sdl2-compat, sdl2-image, virglrenderer, zlib, zstd"
+TERMUX_PKG_DEPENDS="alsa-lib, dtc, gdk-pixbuf, glib, jack2, gtk3, libbz2, libcairo, libcurl, libdw, libepoxy, libgmp, libgnutls, libiconv, libjpeg-turbo, liblzo, libnettle, libnfs, libpixman, libpng, libslirp, libspice-server, libssh, libusb, libusbredir, libx11, mesa, ncurses, pulseaudio, qemu-common-10, resolv-conf, sdl2 | sdl2-compat, sdl2-image, virglrenderer, zlib, zstd"
 # Required by configuration script, but Leonid Pliushch couldn't find any binary that uses it.
 TERMUX_PKG_BUILD_DEPENDS="libtasn1"
 TERMUX_PKG_ANTI_BUILD_DEPENDS="sdl2-compat"


### PR DESCRIPTION
- When https://github.com/termux/termux-packages/pull/30860 is merged, `qemu-system-i386` and all other QEMU packages will disappear from the main repository for 32-bit devices, because QEMU 11 does not support emulating CPUs on 32-bit CPUs anymore.

- However, someone has requested to please continue to provide those packages for 32-bit devices, so this package implements them in TUR using the code of the last QEMU version that supported them.