### PR TITLE
[NEW PACKAGE] tnode v0.1.3

### DIFF
--- a/tur/tnode/build.sh
+++ b/tur/tnode/build.sh
@@ -1,0 +1,28 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/Irithell/tnode
+TERMUX_PKG_DESCRIPTION="POSIX compatibility shim for Android SDCARD filesystem — LD_PRELOAD bridge for Node.js, Python, Ruby, C and C++ runtimes in Termux"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="@Irithell"
+TERMUX_PKG_VERSION="0.1.4"
+TERMUX_PKG_SRCURL=https://github.com/Irithell/tnode/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=720509789e5eb17b79e624582666d97faf835d40927947060808e88f4a6b5b60
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	termux_setup_rust
+}
+
+termux_step_make() {
+	cargo build \
+		--target "$CARGO_TARGET_NAME" \
+		--release \
+		--locked
+}
+
+termux_step_make_install() {
+	install -Dm755 "target/${CARGO_TARGET_NAME}/release/tnode" \
+		"${TERMUX_PREFIX}/bin/tnode"
+
+	install -Dm644 "target/${CARGO_TARGET_NAME}/release/libthook.so" \
+		"${TERMUX_PREFIX}/lib/libthook.so"
+}


### PR DESCRIPTION
tnode is a POSIX compatibility shim for Android's SDCARD filesystem,
distributed as a CLI wrapper (tnode) and a shared library (libthook.so)
injected via LD_PRELOAD.

It transparently patches libc calls that fail on FUSE-backed SDCARD
partitions, enabling Node.js, Python, C, C++, Ruby and more runtimes to
run natively from /storage/emulated/0 in Termux without root or proot.

The build script downloads pre-compiled aarch64 and x86_64 binaries
from the GitHub release and verifies them against checksums.sha256
before installing.

Related upstream contributions during tnode development:
- termux/termux-packages#30831 / #30833 — Go FcntlFlock patch (merged)
- oven-sh/bun#36852 / #36853 — Bun linkat EACCES fallback (merged)