### PR TITLE
addpkg(tur/ffdec): 26.2.1

### DIFF
--- a/tur/ffdec/build.sh
+++ b/tur/ffdec/build.sh
@@ -1,0 +1,62 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/jindrapetrik/jpexs-decompiler
+TERMUX_PKG_DESCRIPTION="JPEXS Free Flash Decompiler"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="26.2.1"
+TERMUX_PKG_GIT_BRANCH="version${TERMUX_PKG_VERSION}"
+TERMUX_PKG_SRCURL="git+https://github.com/jindrapetrik/jpexs-decompiler"
+TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"
+TERMUX_PKG_DEPENDS="openjdk-21, openjdk-21-x"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_HOSTBUILD=true
+
+termux_step_host_build() {
+	if [[ ! -v ANT_HOME ]]; then
+		termux_download_ubuntu_packages ant
+	fi
+}
+
+termux_step_pre_configure() {
+	if [[ ${TERMUX_ON_DEVICE_BUILD} = true ]]; then
+		export JAVA_HOME=${TERMUX__PREFIX__LIB_DIR}/jvm/java-21-openjdk
+	fi
+}
+
+termux_step_make() {
+	export PATH="$TERMUX_PKG_HOSTBUILD_DIR/ubuntu_packages/usr/bin:$PATH"
+	ant build
+}
+
+termux_step_make_install() {
+	mkdir -p $TERMUX__PREFIX/share/java
+	cp -r ./dist/ $TERMUX__PREFIX/share/java/ffdec/
+	cat << EOF > $TERMUX__PREFIX/bin/ffdec
+#!$TERMUX_PREFIX/bin/sh
+
+java -jar $TERMUX__PREFIX/share/java/ffdec/ffdec.jar "\$@"
+EOF
+	cat << EOF > $TERMUX__PREFIX/bin/ffdec-cli
+#!$TERMUX_PREFIX/bin/sh
+
+java -jar $TERMUX__PREFIX/share/java/ffdec/ffdec-cli.jar "\$@"
+EOF
+	chmod 755 $TERMUX__PREFIX/bin/ffdec
+	chmod 755 $TERMUX__PREFIX/bin/ffdec-cli
+	# Removes all Windows executables
+	rm -f $TERMUX__PREFIX/share/java/ffdec/*.exe
+	rm -f $TERMUX__PREFIX/share/java/ffdec/*.bat
+	mkdir -p $TERMUX__PREFIX/share/applications
+	cat << EOF > $TERMUX__PREFIX/share/applications/com.jpexs.decompiler.desktop
+[Desktop Entry]
+Type=Application
+Version=26.2.1
+Name=FFdec
+Comment=JPEXS Free Flash Decompiler
+Exec=ffdec
+Icon=$TERMUX__PREFIX/share/java/ffdec/icon.png
+Categories=Development;
+MimeType=application/x-shockwave-flash;
+EOF
+	chmod +x $TERMUX__PREFIX/share/applications/com.jpexs.decompiler.desktop
+}

--- a/tur/ffdec/fix-paths.patch
+++ b/tur/ffdec/fix-paths.patch
@@ -1,0 +1,39 @@
+diff --git a/build.xml b/build.xml
+index e02160dfb..6f2bd332f 100644
+--- a/build.xml
++++ b/build.xml
+@@ -218,8 +218,8 @@
+             toFile="${app.deb.desktop.temp}"
+             name="${product.name}"
+             comment="${app.description.short}"
+-            exec="/usr/bin/${app.package}"
+-            icon="/usr/share/java/${app.package}/icon.png"
++            exec="@TERMUX_PREFIX@/bin/${app.package}"
++            icon="@TERMUX_PREFIX@/share/java/${app.package}/icon.png"
+             categories="Development;Network;Utility;WebDevelopment;Java"
+         />
+         <deb 
+@@ -231,11 +231,11 @@
+             <version upstream="${version}" />
+             <maintainer name="${vendor}" email="${app.vendor.mail}"/>
+             <description synopsis="${app.description.short}">${app.description}</description>
+-            <tarfileset dir="${dist.dir}" prefix="usr/share/java/${app.package}">
++            <tarfileset dir="${dist.dir}" prefix="@TERMUX_PREFIX@/share/java/${app.package}">
+                 <include name="**"/>
+             </tarfileset>
+-            <tarfileset file="${dist.dir}/${app.script}" fullpath="usr/bin/${app.package}" filemode="755" />
+-            <tarfileset file="${app.deb.desktop.temp}" fullpath="usr/share/applications/${app.deb.desktop.file}.desktop"/>
++            <tarfileset file="${dist.dir}/${app.script}" fullpath="@TERMUX_PREFIX@/bin/${app.package}" filemode="755" />
++            <tarfileset file="${app.deb.desktop.temp}" fullpath="@TERMUX_PREFIX@/share/applications/${app.deb.desktop.file}.desktop"/>
+         </deb>
+         <property name="deb.file" value="${releases.dir}/${prefix.filename}_${version}${version.suffix}.deb" />        
+         <move file="${deb.file.orig}" tofile="${deb.file}" />
+@@ -340,7 +340,7 @@
+     </target>
+     <target name="osx-app-bundle-no-dist" depends="-loadversion">
+         <property name="app.script.temp" value="${app.bundle.dir}/${app.osx.dir}.app/Contents/MacOS/${app.osx.dir}"/>
+-        <echo file="${app.script.temp}">#!/usr/bin/env bash&#10;$(dirname "$${BASH_SOURCE[0]}")/../Resources/${app.script} "$$&#64;"</echo>
++        <echo file="${app.script.temp}">#!@TERMUX_PREFIX@/bin/env bash&#10;$(dirname "$${BASH_SOURCE[0]}")/../Resources/${app.script} "$$&#64;"</echo>
+         <property name="app.info.temp" value="${app.bundle.dir}/${app.osx.dir}.app/Contents/Info.plist"/>
+         <echo file="${app.info.temp}"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+ <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">


### PR DESCRIPTION
This PR will add FFdec (also known as JPEXS Free Flash Decompiler) package to TUR packages list.

~~Build for all architectures through `termux-docker` are successful ([results](https://github.com/TheMightyArie/tur/actions/runs/32141210076)).~~

~~**NOTE**: Since this is a Java application, I could not compile it for TUR. So I skipped that and built it on-device instead.~~