### PR TITLE
addpkg(tur/ppsspp): 1.20.4

### DIFF
--- a/tur/ppsspp/build.sh
+++ b/tur/ppsspp/build.sh
@@ -1,0 +1,67 @@
+TERMUX_PKG_HOMEPAGE=https://www.ppsspp.org/
+TERMUX_PKG_DESCRIPTION="PlayStation Portable emulator"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux-user-repository"
+TERMUX_PKG_VERSION="1.20.4"
+TERMUX_PKG_GIT_BRANCH="v${TERMUX_PKG_VERSION}"
+TERMUX_PKG_SRCURL="git+https://github.com/hrydgard/ppsspp"
+TERMUX_PKG_DEPENDS="sdl2, sdl2-ttf, fontconfig, libcurl, glew, libpng, rapidjson, miniupnpc, zstd, zlib, libzip, libsnappy, libcpufeatures, ffmpeg, spirv-tools"
+TERMUX_PKG_BUILD_DEPENDS="extra-cmake-modules, libglvnd-dev, vulkan-headers, spirv-headers"
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DCMAKE_SYSTEM_NAME=Linux
+-DBUILD_TESTING=OFF
+-DUSING_EGL=ON
+-DUSING_FBDEV=OFF
+-DUSING_GLES2=ON
+-DUSING_X11_VULKAN=ON
+-DUSE_WAYLAND_WSI=OFF
+-DUSE_VULKAN_DISPLAY_KHR=OFF
+-DUSING_QT_UI=OFF
+-DMOBILE_DEVICE=OFF
+-DHEADLESS=ON
+-DATLAS_TOOL=ON
+-DUNITTEST=OFF
+-DSIMULATOR=OFF
+-DLIBRETRO=OFF
+-DUSE_LIBNX=OFF
+-DUSE_FFMPEG=ON
+-DUSE_DISCORD=OFF
+-DUSE_MINIUPNPC=ON
+-DUSE_SYSTEM_SNAPPY=ON
+-DUSE_SYSTEM_FFMPEG=ON
+-DUSE_SYSTEM_FREETYPE=ON
+-DUSE_SYSTEM_LIBCHDR=OFF
+-DUSE_SYSTEM_LIBZIP=ON
+-DUSE_SYSTEM_LIBSDL2=ON
+-DUSE_SYSTEM_LIBPNG=ON
+-DUSE_SYSTEM_RAPIDJSON=ON
+-DUSE_SYSTEM_ZSTD=ON
+-DUSE_SYSTEM_MINIUPNPC=ON
+-DUSE_ASAN=OFF
+-DUSE_UBSAN=OFF
+-DUSE_CCACHE=OFF
+-DUSE_NO_MMAP=OFF
+-DGOLD=OFF
+"
+
+termux_step_pre_configure() {
+	# owokitty magic (do not call me owokitty in final version comments,
+	# Tomjo2000 doesn't like that and it's probably weird)
+	# this is my way of saying this is too hard to explain in one
+	# paragraph and you are not expected to understand this code
+	# (similar to the patch in the luanti package,
+	# see there for more professional comment which I spent
+	# more hours writing)
+	find \
+		"$TERMUX_PKG_SRCDIR"/Common/GPU \
+		"$TERMUX_PKG_SRCDIR"/Common/MsgHandler.h \
+		"$TERMUX_PKG_SRCDIR"/Common/Log.h \
+		"$TERMUX_PKG_SRCDIR"/ppsspp_config.h \
+		"$TERMUX_PKG_SRCDIR"/ext/naett \
+		"$TERMUX_PKG_SRCDIR"/Qt \
+		"$TERMUX_PKG_SRCDIR"/UI \
+		-type f -print0 | xargs -0 sed -i \
+		-e 's/\([^A-Za-z0-9_]__ANDROID\)\(__[^A-Za-z0-9_]\)/\1__DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK\2/g' \
+		-e 's/\([^A-Za-z0-9_]__ANDROID\)__$/\1_DISABLING_THIS_BECAUSE_IT_IS_FOR_BUILDING_AN_APK__/g'
+}

--- a/tur/ppsspp/lower-libpng-req.patch
+++ b/tur/ppsspp/lower-libpng-req.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fa7735adf8..922889fdfe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -844,8 +844,8 @@ else()
+ 	set(LIBZIP_LIBRARY libzip)
+ endif()
+ 
+-# Arm platforms require at least libpng17.
+-if(ANDROID OR ARMV7 OR ARM64 OR ARM OR IOS)
++# Android and iOS require at least libpng17.
++if(ANDROID OR IOS)
+ 	set(PNG_REQUIRED_VERSION 1.7)
+ else()
+ 	set(PNG_REQUIRED_VERSION 1.6)

--- a/tur/ppsspp/shm_open-and-shm_unlink.patch
+++ b/tur/ppsspp/shm_open-and-shm_unlink.patch
@@ -1,0 +1,148 @@
+--- a/Common/MemArenaPosix.cpp
++++ b/Common/MemArenaPosix.cpp
+@@ -19,6 +19,7 @@
+ 
+ #if !defined(_WIN32) && !defined(ANDROID) && !defined(__APPLE__) && !PPSSPP_PLATFORM(SWITCH)
+ 
++#include <alloca.h>
+ #include <sys/mman.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+@@ -37,6 +38,67 @@
+ #include "Common/MemoryUtil.h"
+ #include "Common/MemArena.h"
+ 
++#ifdef __ANDROID__
++static int shm_unlink(const char *name) {
++	size_t namelen;
++	char *fname;
++
++	/* Construct the filename.  */
++	while (name[0] == '/') ++name;
++
++	if (name[0] == '\0') {
++		/* The name "/" is not supported.  */
++		errno = EINVAL;
++		return -1;
++	}
++
++	namelen = strlen(name);
++	fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++	memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++	memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++	return unlink(fname);
++}
++
++static int shm_open(const char *name, int oflag, mode_t mode) {
++	size_t namelen;
++	char *fname;
++	int fd;
++
++	/* Construct the filename.  */
++	while (name[0] == '/') ++name;
++
++	if (name[0] == '\0') {
++		/* The name "/" is not supported.  */
++		errno = EINVAL;
++		return -1;
++	}
++
++	namelen = strlen(name);
++	fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++	memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++	memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++	fd = open(fname, oflag, mode);
++	if (fd != -1) {
++		/* We got a descriptor.  Now set the FD_CLOEXEC bit.  */
++		int flags = fcntl(fd, F_GETFD, 0);
++		flags |= FD_CLOEXEC;
++		flags = fcntl(fd, F_SETFD, flags);
++
++		if (flags == -1) {
++			/* Something went wrong.  We cannot return the descriptor.  */
++			int save_errno = errno;
++			close(fd);
++			fd = -1;
++			errno = save_errno;
++		}
++	}
++
++	return fd;
++}
++#endif
++
+ static const std::string tmpfs_location = "/dev/shm";
+ static const std::string tmpfs_ram_temp_file = "/dev/shm/gc_mem.tmp";
+ 
+--- a/Core/Instance.cpp
++++ b/Core/Instance.cpp
+@@ -35,6 +35,67 @@
+ 
+ #include <cstdint>
+ 
++#ifdef __ANDROID__
++static int shm_unlink(const char *name) {
++	size_t namelen;
++	char *fname;
++
++	/* Construct the filename.  */
++	while (name[0] == '/') ++name;
++
++	if (name[0] == '\0') {
++		/* The name "/" is not supported.  */
++		errno = EINVAL;
++		return -1;
++	}
++
++	namelen = strlen(name);
++	fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++	memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++	memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++	return unlink(fname);
++}
++
++static int shm_open(const char *name, int oflag, mode_t mode) {
++	size_t namelen;
++	char *fname;
++	int fd;
++
++	/* Construct the filename.  */
++	while (name[0] == '/') ++name;
++
++	if (name[0] == '\0') {
++		/* The name "/" is not supported.  */
++		errno = EINVAL;
++		return -1;
++	}
++
++	namelen = strlen(name);
++	fname = (char *) alloca(sizeof("@TERMUX_PREFIX@/tmp/") - 1 + namelen + 1);
++	memcpy(fname, "@TERMUX_PREFIX@/tmp/", sizeof("@TERMUX_PREFIX@/tmp/") - 1);
++	memcpy(fname + sizeof("@TERMUX_PREFIX@/tmp/") - 1, name, namelen + 1);
++
++	fd = open(fname, oflag, mode);
++	if (fd != -1) {
++		/* We got a descriptor.  Now set the FD_CLOEXEC bit.  */
++		int flags = fcntl(fd, F_GETFD, 0);
++		flags |= FD_CLOEXEC;
++		flags = fcntl(fd, F_SETFD, flags);
++
++		if (flags == -1) {
++			/* Something went wrong.  We cannot return the descriptor.  */
++			int save_errno = errno;
++			close(fd);
++			fd = -1;
++			errno = save_errno;
++		}
++	}
++
++	return fd;
++}
++#endif
++
+ uint8_t PPSSPP_ID = 0;
+ 
+ #if PPSSPP_PLATFORM(WINDOWS)


### PR DESCRIPTION
- Fixes #2725

This PR will add PPSSPP (PlayStation Portable emulator) to TUR packages list.

Build for `arm` and `aarch64` are failing ([results](https://github.com/TheMightyArie/tur/actions/runs/32232809478)).
*I have no idea about how can I disable tests for that, so I might need help with it.*

Huge thanks to @Warlord19winter for providing most of the needed patches to make PPSSPP buildable on Termux, their help is appreciated!