### PR TITLE
tur: add yaolang (Chinese keywords programming language)

### DIFF
--- a/tur/yaolang/build.sh
+++ b/tur/yaolang/build.sh
@@ -1,0 +1,16 @@
+# License: MIT
+TERMUX_PKG_HOMEPAGE=https://yaolang.l.cd
+TERMUX_PKG_DESCRIPTION="YaoLang - Programming language with 100% Chinese keywords"
+TERMUX_PKG_MAINTAINER="@a737812"
+TERMUX_PKG_VERSION=0.1.0
+TERMUX_PKG_SRCURL=https://github.com/a737812/yaolang/archive/refs/heads/main.tar.gz
+TERMUX_PKG_SHA256=SKIP
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_DEPENDS="clang"
+termux_step_configure() { return 0; }
+termux_step_make() {
+    $CC -O2 -o yaolang src/yaolang.c -lm
+}
+termux_step_make_install() {
+    install -Dm700 -T yaolang "$TERMUX_PREFIX/bin/yaolang"
+}

--- a/tur/yaolang/build.sh
+++ b/tur/yaolang/build.sh
@@ -1,11 +1,10 @@
 # License: MIT
-TERMUX_PKG_HOMEPAGE=https://yaolang.l.cd
+TERMUX_PKG_HOMEPAGE=https://github.com/a737812/yaolang
 TERMUX_PKG_DESCRIPTION="YaoLang - Programming language with 100% Chinese keywords"
 TERMUX_PKG_MAINTAINER="@a737812"
 TERMUX_PKG_VERSION=0.1.0
-TERMUX_PKG_SRCURL=https://github.com/a737812/yaolang/archive/refs/heads/main.tar.gz
+TERMUX_PKG_SRCURL=https://github.com/a737812/yaolang/archive/refs/tags/v0.1.0.tar.gz
 TERMUX_PKG_SHA256=SKIP
-TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_DEPENDS="clang"
 termux_step_configure() { return 0; }
 termux_step_make() {


### PR DESCRIPTION
## New package: yaolang

**YaoLang** is a compiled programming language with 100% Chinese keywords.

### Features
- Chinese keywords: 函数 变量 若 当 对于 匹配 结构 枚举
- Native compilation: .yao -> C -> machine code
- Static types: 整数 浮点 布尔 文本 字符
- 40+ builtin functions
- Single-file compiler (~3700 lines C)

### Links
- Homepage: https://yaolang.l.cd
- Source: https://github.com/a737812/yaolang
- License: MIT

### Depends
- clang

### Note
Compiles `yaolang.c` into `yaolang` binary at `$PREFIX/bin/yaolang`