### PR TITLE
[WIP] addpkg(tur/tiemu): 3.03, addpkg(tur/tilp): 1.19

### DIFF
--- a/tur/libglade2/build.sh
+++ b/tur/libglade2/build.sh
@@ -1,0 +1,16 @@
+TERMUX_PKG_HOMEPAGE="https://download.gnome.org/sources/libglade/"
+TERMUX_PKG_DESCRIPTION="Library to load .glade files at runtime"
+TERMUX_PKG_LICENSE="LGPL-2.1"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION="2.6.4"
+TERMUX_PKG_SRCURL="https://download.gnome.org/sources/libglade/${TERMUX_PKG_VERSION%.*}/libglade-${TERMUX_PKG_VERSION}.tar.gz"
+TERMUX_PKG_SHA256=c41d189b68457976069073e48d6c14c183075d8b1d8077cb6dfb8b7c5097add3
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="atk, glib, gtk2, libxml2"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-static
+"
+
+termux_step_pre_configure() {
+		LDFLAGS+=" -lgmodule-2.0"
+}

--- a/tur/libticables2/0001-disable-build-tests.patch
+++ b/tur/libticables2/0001-disable-build-tests.patch
@@ -1,0 +1,21 @@
+--- a/Makefile.am	2013-04-13 09:26:51.000000000 -0400
++++ b/Makefile.am	2026-07-29 23:07:46.599235725 -0400
+@@ -3,7 +3,7 @@
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ # Subdirectories to scan
+-SUBDIRS = build/mingw po src tests
++SUBDIRS = build/mingw po src
+ 
+ if USE_DOCGEN
+   SUBDIRS += docs
+--- a/configure.ac	2016-03-23 07:38:40.000000000 -0400
++++ b/configure.ac	2026-07-29 23:08:40.951235725 -0400
+@@ -38,7 +38,6 @@
+   src/Makefile
+   src/win32/dha/Makefile
+   src/win64/rwp/Makefile
+-  tests/Makefile
+   ticables2.pc
+ ])
+ 

--- a/tur/libticables2/0002-instrument-slv_bulk_read2.patch
+++ b/tur/libticables2/0002-instrument-slv_bulk_read2.patch
@@ -1,0 +1,878 @@
+--- a/src/linux/link_usb.c	2016-09-10 15:45:34.000000000 -0400
++++ b/src/linux/link_usb.c	2026-08-12 13:16:39.697000000 -0400
+@@ -96,6 +96,20 @@
+ # include <usb.h>
+ #endif
+ 
++/* Termux porting instrumentation */
++#define SLV_TRACE(level, fmt, ...)                                      \
++       do {                                                               \
++               if (usb_debug >= (level)) {                                    \
++                       struct timeval trace_tv;                                  \
++                       gettimeofday(&trace_tv, NULL);                            \
++                       fprintf(stderr, "[%ld.%03ld] slv_bulk_read2: " fmt "\n",  \
++                               (long)trace_tv.tv_sec,                               \
++                               trace_tv.tv_usec / 1000,                              \
++                               ##__VA_ARGS__);                                       \
++               }                                                              \
++       } while (0)
++/* End instrumentation */
++
+ /* --- */
+ 
+ #ifdef __WIN32__	// found in src/error.h of libusb-win32
+@@ -202,6 +216,9 @@
+ /* variables for slv_check and slv_bulk_read2 */
+ static int io_pending = 0;
+ static struct usb_urb urb;
++
++static int trace_after_halt_recovery = 0;
++static int recovery_reads = 0;
+ #endif
+ 
+ /* --- */
+@@ -285,6 +302,7 @@
+ #define uInEnd              (((usb_struct *)(h->priv2))->in_endpoint)
+ #define uOutEnd             (((usb_struct *)(h->priv2))->out_endpoint)
+ 
++
+ /* Helpers (=driver API) */
+ 
+ static void tigl_get_product(char * string, size_t maxlen, struct usb_device *dev)
+@@ -438,20 +456,55 @@
+ {
+ 	int ret;
+ 
++	fprintf(stderr,
++		"tigl_reset: enter io_pending=%d nBytesRead=%d "
++		"in_ep=0x%02x out_ep=0x%02x fd=%d\n",
++		io_pending,
++		nBytesRead,
++		uInEnd,
++		uOutEnd,
++		uHdl != NULL ? uHdl->fd : -1);
++
+ 	// Reset out pipe
+ 	ret = usb_clear_halt(uHdl, uOutEnd);
++
++	fprintf(stderr,
++		"tigl_reset: clear OUT ep=0x%02x ret=%d",
++		uOutEnd, ret);
++
++	if (ret < 0)
++		fprintf(stderr, " errno=%d (%s)", errno, strerror(errno));
++
++	fprintf(stderr, "\n");
++
+ 	if (ret < 0) 
+ 	{
+ 		ticables_warning("usb_clear_halt of out pipe (%s).\n", usb_strerror());
+ 	}
++
+ 	
+ 	// Reset in pipe
+ 	ret = usb_clear_halt(uHdl, uInEnd);
++
++	fprintf(stderr,
++		"tigl_reset: clear IN ep=0x%02x ret=%d",
++		uInEnd, ret);
++
++	if (ret < 0)
++		fprintf(stderr, " errno=%d (%s)", errno, strerror(errno));
++
++	fprintf(stderr, "\n");
++
+ 	if (ret < 0) 
+ 	{
+ 		ticables_warning("usb_clear_halt of in pipe (%s).\n", usb_strerror());
+ 	}
+ 
++	fprintf(stderr,
++		"tigl_reset: exit io_pending=%d nBytesRead=%d\n",
++		io_pending,
++		nBytesRead);
++
+ 	return 0;
+ }
+ 
+@@ -488,6 +541,13 @@
+ 
+ static int slv_open(CableHandle *h)
+ {
++	fprintf(stderr,
++		"slv_open: enter io_pending=%d nBytesRead=%d "
++		"priv2=%p\n",
++		io_pending,
++		nBytesRead,
++		(void *)h->priv2);
++
+ 	int ret;
+ 	int i;
+ 	struct usb_config_descriptor *config;
+@@ -497,6 +557,17 @@
+ 
+ 	// open device
+ 	ret = tigl_open(h->address, &uHdl);
++
++	fprintf(stderr,
++		"slv_open: tigl_open returned %d handle=%p",
++		ret,
++		(void *)uHdl);
++
++	if (ret == 0 && uHdl != NULL)
++		fprintf(stderr, " fd=%d", uHdl->fd);
++
++	fprintf(stderr, "\n");
++
+ 	if (ret)
+ 	{
+ 		return ret;
+@@ -540,19 +611,101 @@
+ 	nBytesRead = 0;
+ 	was_max_size_packet = 0;
+ 
++	fprintf(stderr,
++		"slv_open: exit io_pending=%d nBytesRead=%d "
++		"in_ep=0x%02x out_ep=0x%02x max_ps=%d "
++		"handle=%p fd=%d\n",
++		io_pending,
++		nBytesRead,
++		uInEnd,
++		uOutEnd,
++		max_ps,
++		(void *)uHdl,
++		uHdl != NULL ? uHdl->fd : -1);
++
+ 	return 0;
+ }
+ 
++#if 0
+ static int slv_close(CableHandle *h)
+ {
++
++	fprintf(stderr,
++		"slv_close: enter io_pending=%d nBytesRead=%d "
++		"priv2=%p handle=%p fd=%d\n",
++		io_pending,
++		nBytesRead,
++		(void *)h->priv2,
++		(void *)uHdl,
++		uHdl != NULL ? uHdl->fd : -1);
++
+ 	if (uHdl != NULL) 
+ 	{
++		fprintf(stderr,
++			"slv_close: calling tigl_close handle=%p fd=%d\n",
++			(void *)uHdl,
++			uHdl->fd);
++
+ 		tigl_close(&uHdl);
++
++		fprintf(stderr,
++			"slv_close: tigl_close returned handle=%p\n",
++			(void *)uHdl);
+ 	}
+ 	uDev = NULL; 
++	free(h->priv2);
++	h->priv2 = NULL;
++	io_pending = FALSE;
++
++	fprintf(stderr,
++		"slv_close: exit io_pending=%d priv2=%p "
++		"handle=%p\n",
++		io_pending,
++		(void *)h->priv2,
++		(void *)uHdl);
++
++	return 0;
++}
++#endif
++
++static int slv_close(CableHandle *h)
++{
++	fprintf(stderr,
++		"slv_close: enter h=%p priv2=%p handle=%p\n",
++		(void *)h,
++		(void *)h->priv2,
++		(void *)uHdl);
++
++	if (uHdl != NULL) {
++		fprintf(stderr,
++			"slv_close: before tigl_close handle=%p fd=%d\n",
++			(void *)uHdl,
++			uHdl->fd);
++
++		tigl_close(&uHdl);
++
++		fprintf(stderr,
++			"slv_close: after tigl_close handle=%p\n",
++			(void *)uHdl);
++	}
++
++	fprintf(stderr, "slv_close: before uDev=NULL\n");
++	uDev = NULL;
++	fprintf(stderr, "slv_close: after uDev=NULL\n");
++
++	fprintf(stderr, "slv_close: before free priv2=%p\n",
++		(void *)h->priv2);
+ 
+ 	free(h->priv2);
++
++	fprintf(stderr, "slv_close: after free\n");
++
+ 	h->priv2 = NULL;
++	fprintf(stderr, "slv_close: after priv2=NULL\n");
++
++	io_pending = FALSE;
++	fprintf(stderr, "slv_close: exit io_pending=%d\n",
++		io_pending);
+ 
+ 	return 0;
+ }
+@@ -567,16 +720,39 @@
+ {
+ 	int ret = 0;
+ 
++	fprintf(stderr,
++		"slv_reset: enter io_pending=%d nBytesRead=%d "
++		"fd=%d\n",
++		io_pending,
++		nBytesRead,
++		uHdl != NULL ? uHdl->fd : -1);
++
+ #if !defined(__BSD__)
+ 	/* Reset both endpoints (send an URB_FUNCTION_RESET_PIPE) */
+ 	ret = tigl_reset(h);
++
++	fprintf(stderr,
++		"slv_reset: tigl_reset returned %d\n",
++		ret);
++
+ 	if (!ret)
+ 	{
+ #ifdef __WIN32__
+ 		/* Reset USB port (send an IOCTL_INTERNAL_USB_RESET_PORT) */
+ 		ret = usb_reset_ex(uHdl, USB_RESET_TYPE_RESET_PORT);
+ #else
++		/*
+ 		ret = usb_reset(uHdl);
++		*/
++		fprintf(stderr, "slv_reset: skipping usb_reset for Termux test\n");
++		ret = 0;
++		fprintf(stderr,
++			"slv_reset: usb_reset skipped; treating result as 0\n");
++		if (ret < 0)
++			fprintf(stderr, " errno=%d (%s)", errno, strerror(errno));
++
++		fprintf(stderr, "\n");
++
+ #endif
+ 
+ 		if (ret < 0)
+@@ -601,15 +777,61 @@
+ 			usleep(500000);
+ #endif
+ 			ret = slv_close(h);
++
++				fprintf(stderr,
++					"slv_reset: after slv_close ret=%d h=%p\n",
++					ret,
++					(void *)h);
++				fflush(stderr);
++
+ 			if (!ret)
+ 			{
+-				h->priv2 = (usb_struct *)calloc(1, sizeof(usb_struct));
+-				ret = slv_open(h);
++				//h->priv2 = (usb_struct *)calloc(1, sizeof(usb_struct));
++				//ret = slv_open(h);
++					fprintf(stderr,
++						"slv_reset: before calloc\n");
++					fflush(stderr);
++
++					usb_struct *new_priv2 =
++						(usb_struct *)calloc(1, sizeof(usb_struct));
++
++					fprintf(stderr,
++						"slv_reset: after calloc new_priv2=%p\n",
++						(void *)new_priv2);
++					fflush(stderr);
++
++					if (new_priv2 == NULL)
++					{
++						fprintf(stderr,
++							"slv_reset: calloc failed\n");
++						return ERR_LIBUSB_OPEN;
++					}
++
++					h->priv2 = new_priv2;
++
++					fprintf(stderr,
++						"slv_reset: assigned h->priv2=%p\n",
++						(void *)h->priv2);
++					fflush(stderr);
++
++					ret = slv_open(h);
++
++					fprintf(stderr,
++						"slv_reset: slv_open returned %d\n",
++						ret);
++					fflush(stderr);
+ 			}
+ 		}
+ 	}
+ #endif
+ 
++	fprintf(stderr,
++		"slv_reset: exit ret=%d io_pending=%d "
++		"nBytesRead=%d\n",
++		ret,
++		io_pending,
++		nBytesRead);
++
+ 	return ret;
+ }
+ 
+@@ -657,15 +879,21 @@
+ 
+ #ifdef __LINUX__
+ #define MAX_READ_WRITE  (16 * 1024)
++
+ static int slv_bulk_read2(usb_dev_handle *dev, int ep, char *bytes, int size,
+ 	int timeout)
+ {
+-	// This is a variant of usb_bulk_read in libusb, edited to take the
+-	// io_pending variable set in slv_check into account.
+-	unsigned int bytesdone = 0, requested;
++	/*
++	 * This is a variant of usb_bulk_read in libusb, edited to take the
++	 * io_pending variable set in slv_check into account.
++	 */
++	unsigned int bytesdone = 0;
++	unsigned int requested;
+ 	struct timeval tv, tv_ref, tv_now;
+ 	void *context;
+-	int ret, waiting;
++	int ret;
++	int waiting;
++	int reap_errno = 0;
+ 
+ 	/*
+ 	 * FIXME: The use of the URB interface is incorrect here if there are
+@@ -674,13 +902,17 @@
+ 	 * in interesting ways.
+ 	 */
+ 
++	SLV_TRACE(2,
++		"enter fd=%d ep=0x%02x size=%d timeout=%d io_pending=%d",
++		dev->fd, ep, size, timeout, io_pending);
++
+ 	/*
+ 	 * Get actual time, and add the timeout value. The result is the absolute
+-	 * time where we have to quit waiting for an message.
++	 * time where we have to quit waiting for a message.
+ 	 */
+ 	gettimeofday(&tv_ref, NULL);
+-	tv_ref.tv_sec = tv_ref.tv_sec + timeout / 1000;
+-	tv_ref.tv_usec = tv_ref.tv_usec + (timeout % 1000) * 1000;
++	tv_ref.tv_sec += timeout / 1000;
++	tv_ref.tv_usec += (timeout % 1000) * 1000;
+ 
+ 	if (tv_ref.tv_usec > 1000000) {
+ 		tv_ref.tv_usec -= 1000000;
+@@ -692,16 +924,15 @@
+ 
+ 		requested = size - bytesdone;
+ 		if (requested > MAX_READ_WRITE)
+-		{
+ 			requested = MAX_READ_WRITE;
+-		}
+ 
+-		if (io_pending)
+-		{
++		if (io_pending) {
++			SLV_TRACE(2,
++				"reusing pending URB fd=%d ep=0x%02x",
++				dev->fd, ep);
++
+ 			io_pending = FALSE;
+-		}
+-		else
+-		{
++		} else {
+ 			urb.type = USB_URB_TYPE_BULK;
+ 			urb.endpoint = ep;
+ 			urb.flags = 0;
+@@ -710,12 +941,39 @@
+ 			urb.usercontext = (void *)(intptr_t)ep;
+ 			urb.signr = 0;
+ 			urb.actual_length = 0;
+-			urb.number_of_packets = 0;	/* don't do isochronous yet */
++			urb.number_of_packets = 0;
++			/* Don't do isochronous transfers yet. */
+ 
+ 			ret = ioctl(dev->fd, IOCTL_USB_SUBMITURB, &urb);
+-			if (ret < 0) {
+-				USB_ERROR_STR(-errno, "error submitting URB: %s", strerror(errno));
+-				return ret;
++
++			{
++				int submit_errno = errno;
++
++				if (ret < 0) {
++					SLV_TRACE(1,
++						"submit FAILED fd=%d ep=0x%02x "
++						"requested=%u ret=%d errno=%d (%s)",
++						dev->fd,
++						ep,
++						requested,
++						ret,
++						submit_errno,
++						strerror(submit_errno));
++
++					USB_ERROR_STR(-submit_errno,
++						"error submitting URB: %s",
++						strerror(submit_errno));
++
++					return ret;
++				}
++
++				SLV_TRACE(3,
++					"submit OK fd=%d ep=0x%02x "
++					"requested=%u usercontext=%p",
++					dev->fd,
++					ep,
++					requested,
++					urb.usercontext);
+ 			}
+ 		}
+ 
+@@ -723,63 +981,322 @@
+ 		FD_SET(dev->fd, &writefds);
+ 
+ 		waiting = 1;
+-		while (((ret = ioctl(dev->fd, IOCTL_USB_REAPURBNDELAY, &context)) == -1) && waiting) {
++
++		while (waiting) {
++			ret = ioctl(dev->fd,
++				IOCTL_USB_REAPURBNDELAY,
++				&context);
++
++			/*
++			 * Save errno immediately. Later calls to select(), gettimeofday(),
++			 * or other functions may overwrite it.
++			 */
++			reap_errno = errno;
++
++			if (ret != -1)
++				break;
++
++			if (reap_errno != EAGAIN)
++				break;
++
+ 			tv.tv_sec = 0;
+-			tv.tv_usec = 1000; // 1 msec
+-			select(dev->fd + 1, NULL, &writefds, NULL, &tv); //sub second wait
++			tv.tv_usec = 1000; /* 1 ms */
+ 
+-			/* compare with actual time, as the select timeout is not that precise */
++			select(dev->fd + 1,
++				NULL,
++				&writefds,
++				NULL,
++				&tv);
++
++			/*
++			 * Compare with actual time because select() timeout
++			 * precision is not sufficient here.
++			 */
+ 			gettimeofday(&tv_now, NULL);
+ 
+ 			if ((tv_now.tv_sec > tv_ref.tv_sec) ||
+-			    ((tv_now.tv_sec == tv_ref.tv_sec) && (tv_now.tv_usec >= tv_ref.tv_usec)))
+-			{
++				((tv_now.tv_sec == tv_ref.tv_sec) &&
++				 (tv_now.tv_usec >= tv_ref.tv_usec))) {
+ 				waiting = 0;
+ 			}
+ 		}
+ 
++		if (ret == 0) {
++			SLV_TRACE(2,
++				"reap COMPLETE fd=%d ep=0x%02x "
++				"requested=%u actual=%d status=%d "
++				"bytesdone_before=%u context=%p",
++				dev->fd,
++				ep,
++				requested,
++				urb.actual_length,
++				urb.status,
++				bytesdone,
++				context);
++		} else if (!waiting) {
++			SLV_TRACE(1,
++				"reap TIMEOUT fd=%d ep=0x%02x "
++				"requested=%u actual=%d status=%d "
++				"bytesdone=%u last_errno=%d (%s)",
++				dev->fd,
++				ep,
++				requested,
++				urb.actual_length,
++				urb.status,
++				bytesdone,
++				reap_errno,
++				strerror(reap_errno));
++		} else {
++			SLV_TRACE(1,
++				"reap ERROR fd=%d ep=0x%02x "
++				"requested=%u actual=%d status=%d "
++				"ret=%d errno=%d (%s)",
++				dev->fd,
++				ep,
++				requested,
++				urb.actual_length,
++				urb.status,
++				ret,
++				reap_errno,
++				strerror(reap_errno));
++		}
++
+ 		/*
+-		 * If there was an error, that wasn't EAGAIN (no completion), then
+-		 * something happened during the reaping and we should return that
+-		 * error now
++		 * The reap ioctl succeeded, but the USB transfer itself failed.
++		 * ret == 0 means the URB was reaped, not that the URB succeeded.
+ 		 */
+-		if (ret < 0 && errno != EAGAIN)
+-		{
+-			USB_ERROR_STR(-errno, "error reaping URB: %s", strerror(errno));
++		if (ret == 0 && urb.status < 0) {
++				if (ret == 0 && urb.status == -EPIPE) {
++					int clear_in;
++					int clear_out;
++					int saved_errno;
++
++					SLV_TRACE(1,
++						"URB stalled fd=%d ep=0x%02x; clearing endpoints",
++						dev->fd, ep);
++
++					clear_in = usb_clear_halt(dev, ep);
++					saved_errno = errno;
++
++					if (clear_in < 0) {
++						SLV_TRACE(1,
++							"clear IN halt FAILED ep=0x%02x ret=%d "
++							"errno=%d (%s)",
++							ep,
++							clear_in,
++							saved_errno,
++							strerror(saved_errno));
++					} else {
++						SLV_TRACE(1,
++							"clear IN halt succeeded ep=0x%02x",
++							ep);
++					}
++
++					clear_out = usb_clear_halt(dev, 0x02);
++					saved_errno = errno;
++
++					if (clear_out < 0) {
++						SLV_TRACE(1,
++							"clear OUT halt FAILED ep=0x02 ret=%d "
++							"errno=%d (%s)",
++							clear_out,
++							saved_errno,
++							strerror(saved_errno));
++					} else {
++						SLV_TRACE(1,
++							"clear OUT halt succeeded ep=0x02");
++					}
++
++					trace_after_halt_recovery = 1;
++					recovery_reads = 0;
++					io_pending = FALSE;
++					return -EPIPE;
++				}
++				/*
++				if (ret == 0 && urb.status == -EPIPE) {
++					int clear_ret;
++					int clear_errno;
++
++					SLV_TRACE(1,
++						"clearing halted endpoint fd=%d ep=0x%02x",
++						dev->fd, ep);
++
++					clear_ret = usb_clear_halt(dev, ep);
++					clear_errno = errno;
++
++					if (clear_ret < 0) {
++						SLV_TRACE(1,
++							"clear halt FAILED fd=%d ep=0x%02x "
++							"ret=%d errno=%d (%s)",
++							dev->fd,
++							ep,
++							clear_ret,
++							clear_errno,
++							strerror(clear_errno));
++					} else {
++						SLV_TRACE(1,
++							"clear halt succeeded fd=%d ep=0x%02x",
++							dev->fd,
++							ep);
++					}
++
++					return -EPIPE;
++				}
++				*/
++
++
++			int urb_status = urb.status;
++
++			SLV_TRACE(1,
++				"URB transfer FAILED fd=%d ep=0x%02x "
++				"requested=%u actual=%d status=%d (%s)",
++				dev->fd,
++				ep,
++				requested,
++				urb.actual_length,
++				urb_status,
++				strerror(-urb_status));
++
++			USB_ERROR_STR(urb_status,
++				"URB transfer failed: %s",
++				strerror(-urb_status));
++
++			return urb_status;
++		}
++
++		/*
++		 * If there was an error other than EAGAIN, something happened
++		 * during reaping and we should report it.
++		 */
++		if (ret < 0 && reap_errno != EAGAIN) {
++			USB_ERROR_STR(-reap_errno,
++				"error reaping URB: %s",
++				strerror(reap_errno));
+ 		}
+ 
+ 		bytesdone += urb.actual_length;
+-	} while (ret == 0 && bytesdone < size && urb.actual_length == requested);
+ 
+-	/* If the URB didn't complete in success or error, then let's unlink it */
++		if (trace_after_halt_recovery && urb.actual_length > 0) {
++				unsigned int i;
++				unsigned int dump_len = urb.actual_length;
++
++				if (dump_len > 32)
++						dump_len = 32;
++
++				fprintf(stderr,
++						"slv_bulk_read2: post-recovery read #%d actual=%d bytes:",
++						recovery_reads,
++						urb.actual_length);
++
++				for (i = 0; i < dump_len; i++)
++						fprintf(stderr, " %02x",
++								(unsigned char)bytes[i]);
++
++				fprintf(stderr, "\n");
++
++				recovery_reads++;
++
++				if (recovery_reads >= 8)
++						trace_after_halt_recovery = 0;
++		}
++
++		SLV_TRACE(2,
++			"progress fd=%d ep=0x%02x "
++			"requested=%u actual=%d bytesdone=%u/%d "
++			"ret=%d waiting=%d",
++			dev->fd,
++			ep,
++			requested,
++			urb.actual_length,
++			bytesdone,
++			size,
++			ret,
++			waiting);
++
++	} while (ret == 0 &&
++		bytesdone < (unsigned int)size &&
++		urb.actual_length == (int)requested);
++
++	/*
++	 * If the URB did not complete successfully, unlink it.
++	 */
+ 	if (ret < 0) {
+ 		int rc;
+ 
+ 		if (!waiting)
+-		{
+ 			rc = -ETIMEDOUT;
+-		}
+ 		else
+-		{
+ 			rc = urb.status;
+-		}
++
++		SLV_TRACE(1,
++			"discarding incomplete URB fd=%d ep=0x%02x "
++			"ret=%d waiting=%d urb_status=%d rc=%d",
++			dev->fd,
++			ep,
++			ret,
++			waiting,
++			urb.status,
++			rc);
+ 
+ 		ret = ioctl(dev->fd, IOCTL_USB_DISCARDURB, &urb);
+-		if (ret < 0 && errno != EINVAL && usb_debug >= 1)
++
+ 		{
+-			fprintf(stderr, "error discarding URB: %s", strerror(errno));
++			int discard_errno = errno;
++
++			if (ret < 0 &&
++				discard_errno != EINVAL &&
++				usb_debug >= 1) {
++				fprintf(stderr,
++					"slv_bulk_read2: discard FAILED "
++					"fd=%d ep=0x%02x ret=%d "
++					"errno=%d (%s)\n",
++					dev->fd,
++					ep,
++					ret,
++					discard_errno,
++					strerror(discard_errno));
++			}
+ 		}
+ 
+ 		/*
+-		 * When the URB is unlinked, it gets moved to the completed list and
+-		 * then we need to reap it or else the next time we call this function,
+-		 * we'll get the previous completion and exit early
++		 * When the URB is unlinked, it moves to the completed list.
++		 * Reap it so the next call does not receive this old completion.
+ 		 */
+-		ioctl(dev->fd, IOCTL_USB_REAPURB, &context);
++		ret = ioctl(dev->fd,
++			IOCTL_USB_REAPURB,
++			&context);
++
++		{
++			int cleanup_errno = errno;
++
++			if (ret < 0 && usb_debug >= 2) {
++				fprintf(stderr,
++					"slv_bulk_read2: cleanup reap "
++					"fd=%d ep=0x%02x ret=%d "
++					"errno=%d (%s)\n",
++					dev->fd,
++					ep,
++					ret,
++					cleanup_errno,
++					strerror(cleanup_errno));
++			}
++		}
++
++		SLV_TRACE(1,
++			"return ERROR fd=%d ep=0x%02x rc=%d",
++			dev->fd,
++			ep,
++			rc);
+ 
+ 		return rc;
+ 	}
+ 
++	SLV_TRACE(2,
++		"return fd=%d ep=0x%02x result=%u",
++		dev->fd,
++		ep,
++		bytesdone);
++
+ 	return bytesdone;
+ }
+ #endif
+@@ -862,6 +1379,13 @@
+ 			ret = usb_bulk_read(uHdl, uInEnd, (char*)rBuf, max_ps, to);
+ #endif
+ 
++			SLV_TRACE(1,
++					"slv_get_: slv_bulk_read2 returned %d "
++					"nBytesRead=%d io_pending=%d",
++					ret,
++					nBytesRead,
++					io_pending);
++
+ 			if (ret == max_ps)
+ 			{
+ 				was_max_size_packet = 1;
+@@ -887,18 +1411,27 @@
+ 
+ 		if (ret == -ETIMEDOUT) 
+ 		{
++			SLV_TRACE(1,
++				"slv_get_: mapping EPIPE to ERR_READ_ERROR");
++
+ 			ticables_warning("usb_bulk_read (%s).\n", usb_strerror());
+ 			nBytesRead = 0;
+ 			return ERR_READ_TIMEOUT;
+ 		} 
+ 		else if (ret == -EPIPE) 
+ 		{
++			SLV_TRACE(1,
++				"slv_get_: mapping EPIPE to ERR_READ_ERROR");
+ 			ticables_warning("usb_bulk_read (%s).\n", usb_strerror());
++
+ 			nBytesRead = 0;
+ 			return ERR_READ_ERROR;
+ 		} 
+ 		else if (ret < 0) 
+ 		{
++			SLV_TRACE(1,
++				"slv_get_: mapping EPIPE to ERR_READ_ERROR");
++
+ 			ticables_warning("usb_bulk_read (%s).\n", usb_strerror());
+ 			nBytesRead = 0;
+ 			return ERR_READ_ERROR;
+@@ -911,6 +1444,12 @@
+ 	*data = *rBufPtr++;
+ 	nBytesRead--;
+ 
++	SLV_TRACE(1,
++        "slv_get_: returning %d nBytesRead=%d io_pending=%d",
++        ret,
++        nBytesRead,
++        io_pending);
++
+ 	return 0;
+ }
+ 
+@@ -949,6 +1488,11 @@
+ 		}
+ 	}
+ 
++    SLV_TRACE(1,
++        "slv_get: returning %d after requesting len=%u",
++        ret,
++        len);
++
+ 	return ret;
+ }
+ 
+@@ -1052,6 +1596,14 @@
+ 		return ERR_READ_ERROR;
+ 	}
+ 
++	fprintf(stderr,
++			"slv_check: reap ret=%d io_pending=%d "
++			"actual=%d status=%d\n",
++			ret,
++			io_pending,
++			urb.actual_length,
++			urb.status);
++
+ 	if (ret >= 0)
+ 	{
+ 		io_pending = FALSE;

--- a/tur/libticables2/0003-fix-tmp-location.patch
+++ b/tur/libticables2/0003-fix-tmp-location.patch
@@ -1,0 +1,41 @@
+--- a/src/linux/link_tie.c	2016-04-04 01:59:39.000000000 -0400
++++ b/src/linux/link_tie.c	2026-08-12 20:59:27.361000000 -0400
+@@ -63,15 +63,15 @@
+ 
+ static const char fifo_names[4][256] = 
+ {
+-	"/tmp/.vlc_1_0", "/tmp/.vlc_0_1",
+-	"/tmp/.vlc_0_1", "/tmp/.vlc_1_0"
++	"@TERMUX_PREFIX@/tmp/.vlc_1_0", "/tmp/.vlc_0_1",
++	"@TERMUX_PREFIX@/tmp/.vlc_0_1", "/tmp/.vlc_1_0"
+ };
+ 
+ static int shm_check(void)
+ {
+ 	int shmid_;
+ 
+-	if ((ipc_key = ftok("/tmp", 0x1234)) == -1)
++	if ((ipc_key = ftok("@TERMUX_PREFIX@/tmp", 0x1234)) == -1)
+ 	{
+ 		return ERR_TIE_OPEN;
+ 	}
+@@ -117,7 +117,7 @@
+ 	int p = h->address;
+ 	int new = 0;
+ 
+-	if ((ipc_key = ftok("/tmp", 0x1234)) == -1)
++	if ((ipc_key = ftok("@TERMUX_PREFIX@/tmp", 0x1234)) == -1)
+ 	{
+ 		return ERR_TIE_OPEN;
+ 	}
+--- a/src/linux/link_vti.c	2016-04-04 01:59:39.000000000 -0400
++++ b/src/linux/link_vti.c	2026-08-12 21:03:44.965000000 -0400
+@@ -95,7 +95,7 @@
+ 	/* Get a unique (if possible) key */
+ 	for (i = 0; i < 2; i++)
+ 	{
+-		if ((ipc_key[i] = ftok("/tmp", i)) == -1)
++		if ((ipc_key[i] = ftok("@TERMUX_PREFIX/tmp", i)) == -1)
+ 		{
+ 			ticables_warning("unable to get unique key (ftok).\n");
+ 			return ERR_VTI_IPCKEY;

--- a/tur/libticables2/build.sh
+++ b/tur/libticables2/build.sh
@@ -1,0 +1,18 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"
+TERMUX_PKG_DESCRIPTION="Provides libticables2 library and headers for TiEmu and TiLP"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=1.3.5
+TERMUX_PKG_SRCURL="https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/libticables2-${TERMUX_PKG_VERSION}.tar.bz2"
+TERMUX_PKG_SHA256=0c6fb6516e72ccab081ddb3aecceff694ed93aec689ddd2edba9c7c7406c4522
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="glib, libandroid-shmem, libusb"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--enable-libusb10
+"
+
+termux_step_pre_configure() {
+		autoreconf -fi
+		LDFLAGS+=" -landroid-shmem"
+}
+

--- a/tur/libticalcs2/0001-disable-build-tests.patch
+++ b/tur/libticalcs2/0001-disable-build-tests.patch
@@ -1,0 +1,21 @@
+--- a/Makefile.am	2013-04-13 09:26:52.000000000 -0400
++++ b/Makefile.am	2026-07-29 23:12:17.215235725 -0400
+@@ -3,7 +3,7 @@
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ # Subdirectories to scan
+-SUBDIRS = build/mingw po src tests
++SUBDIRS = build/mingw po src
+ 
+ if USE_DOCGEN
+   SUBDIRS += docs
+--- a/configure.ac	2016-04-04 01:59:39.000000000 -0400
++++ b/configure.ac	2026-07-29 23:12:55.891235725 -0400
+@@ -42,7 +42,6 @@
+   src/romdump_9x/Makefile
+   src/romdump_89t_usb/Makefile
+   src/romdump_834pce_usb/Makefile
+-  tests/Makefile
+   ticalcs2.pc
+ ])
+ 

--- a/tur/libticalcs2/build.sh
+++ b/tur/libticalcs2/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"
+TERMUX_PKG_DESCRIPTION="Provides libticalcs2 library and headers for TiEmu and TiLP"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=1.1.9
+TERMUX_PKG_SRCURL="https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/libticalcs2-${TERMUX_PKG_VERSION}.tar.bz2"
+TERMUX_PKG_SHA256=76780788bc309b647f97513d38dd5f01611c335a72855e0bd10c7bdbf2e38921
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="gettext, glib, libticonv, libticables2, libtifiles2"
+
+termux_step_pre_configure() {
+		autoreconf -fi
+}

--- a/tur/libticonv/0001-disable-build-tests.patch
+++ b/tur/libticonv/0001-disable-build-tests.patch
@@ -1,0 +1,21 @@
+--- a/configure.ac	2016-03-23 07:38:40.000000000 -0400
++++ b/configure.ac	2026-07-29 21:57:56.223235725 -0400
+@@ -35,7 +35,6 @@
+   build/mingw/Makefile
+   docs/Makefile
+   src/Makefile
+-  tests/Makefile
+   ticonv.pc
+ ])
+ 
+--- a/Makefile.am	2013-04-13 09:26:51.000000000 -0400
++++ b/Makefile.am	2026-07-29 22:06:10.503235725 -0400
+@@ -3,7 +3,7 @@
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ # Subdirectories to scan
+-SUBDIRS = build/mingw src tests
++SUBDIRS = build/mingw src
+ 
+ if USE_DOCGEN
+   SUBDIRS += docs

--- a/tur/libticonv/build.sh
+++ b/tur/libticonv/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"
+TERMUX_PKG_DESCRIPTION="Provides libticonv libraries and headers for TiEmu and TiLP"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=1.1.5
+TERMUX_PKG_SRCURL="https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/libticonv-${TERMUX_PKG_VERSION}.tar.bz2"
+TERMUX_PKG_SHA256=316da6a73bf26b266dd23443882abc4c9fe7013edc3a53e5e301d525c2060878
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="glib"
+
+termux_step_pre_configure() {
+		autoreconf -fi
+}

--- a/tur/libtifiles2/0001-disable-build-tests.patch
+++ b/tur/libtifiles2/0001-disable-build-tests.patch
@@ -1,0 +1,21 @@
+--- a/Makefile.am	2013-04-13 09:26:53.000000000 -0400
++++ b/Makefile.am	2026-07-29 22:50:06.027235725 -0400
+@@ -3,7 +3,7 @@
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ # Subdirectories to scan
+-SUBDIRS = build/mingw po src tests
++SUBDIRS = build/mingw po src
+ 
+ if USE_DOCGEN
+   SUBDIRS += docs
+--- a/configure.ac	2016-04-04 01:59:39.000000000 -0400
++++ b/configure.ac	2026-07-29 22:51:08.891235725 -0400
+@@ -36,7 +36,6 @@
+   docs/Makefile
+   po/Makefile.in
+   src/Makefile
+-  tests/Makefile
+   tifiles2.pc
+ ])
+ 

--- a/tur/libtifiles2/0002-src-misc-c-fix-foldername-omission.patch
+++ b/tur/libtifiles2/0002-src-misc-c-fix-foldername-omission.patch
@@ -1,0 +1,11 @@
+--- a/src/misc.c	2016-04-04 01:59:39.000000000 -0400
++++ b/src/misc.c	2026-08-07 12:10:50.433797888 -0400
+@@ -288,7 +288,7 @@
+ 
+ 	if (tifiles_has_folder(model)) 
+ 	{
+-		if (fldname[0] == 0)
++		if (fldname[0] != 0)
+ 		{
+ 			sprintf(full_name, "%s\\%s", fldname, varname);
+ 		}

--- a/tur/libtifiles2/build.sh
+++ b/tur/libtifiles2/build.sh
@@ -1,0 +1,13 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"
+TERMUX_PKG_DESCRIPTION="Provides libtifiles2 library and headers for TiEmu and TiLP"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=1.1.7
+TERMUX_PKG_SRCURL="https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/libtifiles2-${TERMUX_PKG_VERSION}.tar.bz2"
+TERMUX_PKG_SHA256=9ac63b49e97b09b30b37bbc84aeb15fa7967bceb944e56141c5cd5a528acc982
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="glib, libarchive, libticonv"
+
+termux_step_pre_configure() {
+		autoreconf -fi
+}

--- a/tur/pedrom/build.sh
+++ b/tur/pedrom/build.sh
@@ -1,0 +1,38 @@
+TERMUX_PKG_HOMEPAGE="https://t3.yaronet.com/?id=19"
+TERMUX_PKG_DESCRIPTION="PedroM is an open source Operating System for Ti-68k calculators."
+TERMUX_PKG_LICENSE="GPL-2.0-or-later"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION="0.83"
+TERMUX_PKG_SRCURL="https://ticalc.org/pub/89/os/pedrom.zip"
+TERMUX_PKG_SHA256=bee0400235ac7c29c890a55be79018f7e561688374a343c01a4fc1f478135cfc
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+
+termux_step_configure() {
+		:
+}
+
+termux_step_make() {
+		:
+}
+
+termux_step_make_install() {
+		local src="$TERMUX_PKG_SRCDIR"
+		#local pedrom_dir="$TERMUX_PREFIX/share/pedrom"
+		local tiemu_dir="$TERMUX_PREFIX/share/tiemu/pedrom"
+
+		#mkdir -p "$pedrom_dir" "$tiemu_dir"
+
+		# Install the complete PedroM distribution.
+		#cp -a "$src"/. "$pedrom_dir"/
+
+		# Make working images available to TiEmu's startup scanner.
+		for image in \
+				PedroM-89.89u \
+				PedroM-89ti.89u \
+				PedroM-9x.9xu \
+				PedroM-v2.9xu
+		do
+				install -Dm644 "$src/$image" "$tiemu_dir/$image"
+		done
+}

--- a/tur/tiemu/0000-fix-tmp-path.patch
+++ b/tur/tiemu/0000-fix-tmp-path.patch
@@ -1,0 +1,11 @@
+--- a/src/misc/paths.h	2006-07-30 17:32:36.000000000 -0400
++++ b/src/misc/paths.h	2026-08-12 21:40:22.517000000 -0400
+@@ -33,7 +33,7 @@
+ # define CONF_DIR   	".tiemu/"
+ # define INI_FILE    	"tiemu.ini"
+ # define CACHE_FILE 	"img_list.txt"
+-# define LOG_FILE 		"/tmp/tiemu.log"
++# define LOG_FILE 		"@TERMUX_PREFIX@/tmp/tiemu.log"
+ #elif defined(__WIN32__)
+ # define CONF_DIR   	""
+ # define INI_FILE    	"tiemu.ini"

--- a/tur/tiemu/0001-src-core-uae-use-hostcc-and-gnu89-for-generators.patch
+++ b/tur/tiemu/0001-src-core-uae-use-hostcc-and-gnu89-for-generators.patch
@@ -1,0 +1,46 @@
+--- a/src/core/uae/Makefile	2006-01-06 18:30:04.000000000 -0500
++++ b/src/core/uae/Makefile	2026-07-30 14:58:01.182347313 -0400
+@@ -6,6 +6,8 @@
+ # trying to be portable... *TRYING*
+ #CFLAGS   = -mms-bitfields
+ CPUFLAGS = $(CFLAGS) -fomit-frame-pointer -Wno-unused -Wno-format -W -Wmissing-prototypes -Wstrict-prototypes -D__inline__=inline -DSTATFS_NO_ARGS=2 -DSTATBUF_BAVAIL=f_bavail #-Wall
++HOSTCC ?= gcc
++HOSTCFLAGS ?= -std=gnu89
+ 
+ gen: cpudefs.c cpustbl.c cputbl.h cpuemu.c
+ 
+@@ -14,26 +16,26 @@
+ 
+ # For cross-compiling (generators are run on host)
+ build68k_host.o: build68k.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ gencpu_host.o: gencpu.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ readcpu_host.o: readcpu.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ cpudefs_host.o: cpudefs.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ missing_host.o: missing.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ xmalloc_host.o: xmalloc.c
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc -c -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -c -o $@ $?
+ 
+ # Build generators and files to generate
+ build68k: build68k_host.o
+ 	@echo "-> Compiling 68k builder..."
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc $(LDFLAGS) -o $@ $?
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -o $@ $?
+ 
+ gencpu: gencpu_host.o readcpu_host.o cpudefs_host.o missing_host.o xmalloc_host.o
+ 	@echo "-> Compiling CPU generator..."
+-	C_INCLUDE_PATH="" LIBRARY_PATH="" gcc $(LDFLAGS) -o $@ gencpu_host.o readcpu_host.o cpudefs_host.o missing_host.o xmalloc_host.o
++	C_INCLUDE_PATH="" LIBRARY_PATH="" $(HOSTCC) $(HOSTCFLAGS) -o $@ gencpu_host.o readcpu_host.o cpudefs_host.o missing_host.o xmalloc_host.o
+ 
+ cpudefs.c: build68k table68k
+ 	@echo "-> Building CPU definitions..."

--- a/tur/tiemu/0002-src-core-uae-newcpu-include-romcalls-and-handles.patch
+++ b/tur/tiemu/0002-src-core-uae-newcpu-include-romcalls-and-handles.patch
@@ -1,0 +1,11 @@
+--- a/src/core/uae/newcpu.c	2008-05-25 09:08:41.000000000 -0400
++++ b/src/core/uae/newcpu.c	2026-07-30 15:31:51.990347313 -0400
+@@ -30,6 +30,8 @@
+ extern const char *symfile;
+ #endif /* CYGNUS_SIM */
+ #define FLOATFORMAT_H /* don't include glib.h in romcalls.h */
++#include "romcalls.h"
++#include "handles.h"
+ // tiemu end
+ 
+ /* Opcode of faulting instruction */

--- a/tur/tiemu/0003-src-core-uae-drop-abort-macro-override.patch
+++ b/tur/tiemu/0003-src-core-uae-drop-abort-macro-override.patch
@@ -1,0 +1,19 @@
+--- a/src/core/uae/sysdeps.h	2007-06-24 01:05:05.000000000 -0400
++++ b/src/core/uae/sysdeps.h	2026-07-30 16:53:11.346347313 -0400
+@@ -137,12 +137,16 @@
+ #define ENUMDECL typedef enum
+ #define ENUMNAME(name) name
+ 
++/* Remove macro; collides with libc abort()*/
++#if 0
+ /* While we're here, make abort more useful.  */
+ #define abort() \
+   do { \
+     fprintf (stderr, "UAE: Internal error; file %s, line %d\n", __FILE__, __LINE__); \
+     (abort) (); \
+ } while (0)
++#endif
++
+ #else
+ #define ENUMDECL enum
+ #define ENUMNAME(name) ; typedef int name

--- a/tur/tiemu/0004-gui-about-use-gtk-about-dialog-set-program-name.patch
+++ b/tur/tiemu/0004-gui-about-use-gtk-about-dialog-set-program-name.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/about.c	2007-04-15 04:29:34.000000000 -0400
++++ b/src/gui/about.c	2026-07-30 17:31:17.522347313 -0400
+@@ -103,7 +103,7 @@
+ 	dlg = GTK_ABOUT_DIALOG(widget);
+ 	pix = create_pixbuf("logo.xpm");
+ 
+-	gtk_about_dialog_set_name(dlg, "TiEmu - Ti Emulator - ");
++	gtk_about_dialog_set_program_name(dlg, "TiEmu - Ti Emulator - ");
+ 	gtk_about_dialog_set_version(dlg, TIEMU_VERSION);
+ 	gtk_about_dialog_set_comments(dlg, version);
+ 	gtk_about_dialog_set_copyright(dlg, "Copyright (c) 1999-2007 The TiEmu Team");

--- a/tur/tiemu/0005-gui-calc-use-gsourcefunc-for-timeout-callback.patch
+++ b/tur/tiemu/0005-gui-calc-use-gsourcefunc-for-timeout-callback.patch
@@ -1,0 +1,29 @@
+--- a/src/gui/calc/calc.c	2007-12-16 10:29:16.000000000 -0500
++++ b/src/gui/calc/calc.c	2026-07-30 17:57:39.190347313 -0400
+@@ -313,7 +313,7 @@
+ {
+     gdk_draw_pixmap(
+         widget->window,
+-		widget->style->fg_gc[GTK_WIDGET_STATE (widget)],
++		widget->style->fg_gc[gtk_widget_get_state(widget)],
+ 		pixmap,
+ 		event->area.x, event->area.y,
+ 		event->area.x, event->area.y,
+@@ -586,7 +586,7 @@
+ 
+     // Install LCD refresh: 100 FPS (10 ms)
+     tid = g_timeout_add((params.lcd_rate == -1) ? 50 : params.lcd_rate, 
+-		(GtkFunction)hid_refresh, NULL);
++		(GSourceFunc)hid_refresh, NULL);
+ 
+ 	explicit_destroy = 0;
+ 	gtk_widget_show(main_wnd);	// show wnd here
+@@ -640,7 +640,7 @@
+ 	g_source_remove(tid);
+ 
+ 	tid = g_timeout_add((params.lcd_rate == -1) ? 50 : params.lcd_rate, 
+-		(GtkFunction)hid_refresh, NULL);
++		(GSourceFunc)hid_refresh, NULL);
+ }
+ 
+ int hid_switch_with_skin(void)

--- a/tur/tiemu/0006-gui-screen-use-gtk_widget_get_state.patch
+++ b/tur/tiemu/0006-gui-screen-use-gtk_widget_get_state.patch
@@ -1,0 +1,38 @@
+--- a/src/gui/calc/screen.c	2006-11-06 12:18:51.000000000 -0500
++++ b/src/gui/calc/screen.c	2026-07-30 18:08:42.554347313 -0400
+@@ -187,7 +187,7 @@
+ 	skin_infos.image = gdk_pixbuf_scale_simple(skin_infos.raw, wr.wr.w, wr.wr.h, GDK_INTERP_NEAREST);
+ 
+ 	// and draw image into pixmap (next, into window on expose event)
+-    gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[GTK_WIDGET_STATE(main_wnd)],
++    gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[gtk_widget_get_state(main_wnd)],
+ 		  skin_infos.image, 0, 0, 0, 0, -1, -1, GDK_RGB_DITHER_NONE, 0, 0);
+ 	gdk_window_invalidate_rect(main_wnd->window, &wr.gr, FALSE);
+ }
+@@ -204,7 +204,7 @@
+ 		gdk_pixbuf_scale_simple(skin_infos.raw, sr.w, sr.h, GDK_INTERP_NEAREST);
+ 
+ 	// and draw
+-	gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[GTK_WIDGET_STATE(main_wnd)],
++	gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[gtk_widget_get_state(main_wnd)],
+ 		  skin_infos.image, ls.x, ls.y, lr.x, lr.y, lr.w, lr.h, GDK_RGB_DITHER_NONE, 0, 0);
+ 	gtk_widget_queue_draw_area(area, lr.x, lr.y, lr.w, lr.h);
+ }
+@@ -324,7 +324,7 @@
+ 			skin_infos.image = gdk_pixbuf_scale_simple(lcd, lr.w, lr.h, GDK_INTERP_NEAREST);
+ 
+ 			// and draw image into pixmap (next, into window on expose event)
+-			gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[GTK_WIDGET_STATE(main_wnd)],
++			gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[gtk_widget_get_state(main_wnd)],
+ 			 skin_infos.image, src.x, src.y, lr.x, lr.y, src.w, src.h,
+ 			  GDK_RGB_DITHER_NONE, 0, 0);
+ 			gtk_widget_queue_draw_area(area, lr.x, lr.y, src.w, src.h);
+@@ -332,7 +332,7 @@
+ 		else
+ 		{
+ 			// and draw image into pixmap (next, into window on expose event)
+-			gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[GTK_WIDGET_STATE(main_wnd)],
++			gdk_draw_pixbuf(pixmap, main_wnd->style->fg_gc[gtk_widget_get_state(main_wnd)],
+ 			  lcd_mem, src.x, src.y, lr.x, lr.y, src.w, src.h,
+ 			  GDK_RGB_DITHER_NONE, 0, 0);
+ 			gtk_widget_queue_draw_area(area, lr.x, lr.y, src.w, src.h);

--- a/tur/tiemu/0007-gui-debugger-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0007-gui-debugger-gtk_widget_get_visible.patch
@@ -1,0 +1,50 @@
+--- a/src/gui/debugger/dbg_all.c	2009-05-08 06:56:40.000000000 -0400
++++ b/src/gui/debugger/dbg_all.c	2026-07-30 18:33:31.750347313 -0400
+@@ -90,21 +90,21 @@
+ {	
+ 	WND_TMR_START();
+ 
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.regs))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.regs))
+ 		dbgregs_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.mem))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.mem))
+ 		dbgmem_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.bkpts))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.bkpts))
+ 		dbgbkpts_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.pclog))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.pclog))
+ 		dbgpclog_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.code))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.code))
+ 		dbgcode_refresh_window();
+-    if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(options3.dbg_dock || gtk_widget_get_visible(dbgw.stack))
+ 		dbgstack_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.heap))
+ 		dbgheap_refresh_window();
+-	if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(options3.dbg_dock || gtk_widget_get_visible(dbgw.iop))
+ 		dbgiop_refresh_window();
+ 
+ 	WND_TMR_STOP("Debugger Refresh Time");
+@@ -163,7 +163,7 @@
+ 	gtk_debugger_refresh();
+ 
+ 	// enable the debugger if GDB disabled it
+-	if (!options3.dbg_dock && !GTK_WIDGET_SENSITIVE(dbgw.regs))
++	if (!options3.dbg_dock && !gtk_widget_get_sensitive(dbgw.regs))
+ 		gtk_debugger_enable();
+ 
+ 	// handle automatic debugging requests
+@@ -180,7 +180,7 @@
+ 
+ 			ti68k_bkpt_get_pgmentry_offset(id, &handle, &offset);
+ 			ti68k_bkpt_del_pgmentry(handle);
+-			if(options3.dbg_dock || GTK_WIDGET_VISIBLE(dbgw.bkpts))
++			if(options3.dbg_dock || gtk_widget_get_visible(dbgw.bkpts))
+ 				dbgbkpts_refresh_window();
+ 
+ 			delete_command(NULL, 0);

--- a/tur/tiemu/0008-gui-debugger-dbg_wnds-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0008-gui-debugger-dbg_wnds-gtk_widget_get_visible.patch
@@ -1,0 +1,185 @@
+--- a/src/gui/debugger/dbg_wnds.c	2009-05-07 03:18:02.000000000 -0400
++++ b/src/gui/debugger/dbg_wnds.c	2026-07-30 18:58:11.478347313 -0400
+@@ -74,21 +74,21 @@
+ 	if(options3.dbg_dock)
+ 		return;
+ 
+-    if(GTK_WIDGET_VISIBLE(dbgw.regs))
++    if(gtk_widget_get_visible(dbgw.regs))
+         gtk_window_iconify(GTK_WINDOW(dbgw.regs));
+-    if(GTK_WIDGET_VISIBLE(dbgw.bkpts))
++    if(gtk_widget_get_visible(dbgw.bkpts))
+         gtk_window_iconify(GTK_WINDOW(dbgw.bkpts));
+-    if(GTK_WIDGET_VISIBLE(dbgw.mem))
++    if(gtk_widget_get_visible(dbgw.mem))
+         gtk_window_iconify(GTK_WINDOW(dbgw.mem));
+-    if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_window_iconify(GTK_WINDOW(dbgw.pclog));
+-    if(GTK_WIDGET_VISIBLE(dbgw.code) & all)
++    if(gtk_widget_get_visible(dbgw.code) & all)
+         gtk_window_iconify(GTK_WINDOW(dbgw.code));
+-    if(GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(gtk_widget_get_visible(dbgw.stack))
+         gtk_window_iconify(GTK_WINDOW(dbgw.stack));
+-	if(GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(gtk_widget_get_visible(dbgw.heap))
+         gtk_window_iconify(GTK_WINDOW(dbgw.heap));
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_window_iconify(GTK_WINDOW(dbgw.iop));
+ }
+ 
+@@ -98,21 +98,21 @@
+ 	if(options3.dbg_dock)
+ 		return;
+ 
+-    if(GTK_WIDGET_VISIBLE(dbgw.regs))
++    if(gtk_widget_get_visible(dbgw.regs))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.regs));
+-    if(GTK_WIDGET_VISIBLE(dbgw.bkpts))
++    if(gtk_widget_get_visible(dbgw.bkpts))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.bkpts));
+-    if(GTK_WIDGET_VISIBLE(dbgw.mem))
++    if(gtk_widget_get_visible(dbgw.mem))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.mem));
+-    if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.pclog));
+-    if(GTK_WIDGET_VISIBLE(dbgw.code) & all)
++    if(gtk_widget_get_visible(dbgw.code) & all)
+         gtk_window_deiconify(GTK_WINDOW(dbgw.code));
+-    if(GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(gtk_widget_get_visible(dbgw.stack))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.stack));
+-	if(GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(gtk_widget_get_visible(dbgw.heap))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.heap));
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_window_deiconify(GTK_WINDOW(dbgw.iop));
+ }
+ 
+@@ -122,21 +122,21 @@
+     if(options3.dbg_dock)
+ 		return;
+ 
+-    if(!GTK_WIDGET_VISIBLE(dbgw.regs))
++    if(!gtk_widget_get_visible(dbgw.regs))
+         gtk_widget_show(dbgw.regs);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.bkpts))
++    if(!gtk_widget_get_visible(dbgw.bkpts))
+         gtk_widget_show(dbgw.bkpts);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.mem))
++    if(!gtk_widget_get_visible(dbgw.mem))
+         gtk_widget_show(dbgw.mem);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(!gtk_widget_get_visible(dbgw.pclog))
+         gtk_widget_show(dbgw.pclog);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.code) && all)
++    if(!gtk_widget_get_visible(dbgw.code) && all)
+         gtk_widget_show(dbgw.code);
+-    if(!GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(!gtk_widget_get_visible(dbgw.stack))
+         gtk_widget_show(dbgw.stack);
+-	if(!GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(!gtk_widget_get_visible(dbgw.heap))
+         gtk_widget_show(dbgw.heap);
+-	if(!GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(!gtk_widget_get_visible(dbgw.iop))
+         gtk_widget_show(dbgw.iop);
+ }
+ 
+@@ -146,21 +146,21 @@
+     if(options3.dbg_dock)
+ 		return;
+ 
+-    if(GTK_WIDGET_VISIBLE(dbgw.regs))
++    if(gtk_widget_get_visible(dbgw.regs))
+         gtk_widget_hide(dbgw.regs);
+-    if(GTK_WIDGET_VISIBLE(dbgw.bkpts))
++    if(gtk_widget_get_visible(dbgw.bkpts))
+         gtk_widget_hide(dbgw.bkpts);
+-    if(GTK_WIDGET_VISIBLE(dbgw.mem))
++    if(gtk_widget_get_visible(dbgw.mem))
+         gtk_widget_hide(dbgw.mem);
+-    if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_widget_hide(dbgw.pclog);
+-    if(GTK_WIDGET_VISIBLE(dbgw.code) && all)
++    if(gtk_widget_get_visible(dbgw.code) && all)
+         gtk_widget_hide(dbgw.code);
+-    if(GTK_WIDGET_VISIBLE(dbgw.stack))
++    if(gtk_widget_get_visible(dbgw.stack))
+         gtk_widget_hide(dbgw.stack);
+-	if(GTK_WIDGET_VISIBLE(dbgw.heap))
++	if(gtk_widget_get_visible(dbgw.heap))
+         gtk_widget_hide(dbgw.heap);
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_widget_hide(dbgw.iop);
+ }
+ 
+@@ -338,7 +338,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_registers1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.regs));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.regs));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_registers1_activate, NULL);
+ 	}
+ 	else
+@@ -350,7 +350,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_breakpoints1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.bkpts));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.bkpts));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_breakpoints1_activate, NULL);
+ 	}
+ 	else
+@@ -362,7 +362,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_memory1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.mem));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.mem));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_memory1_activate, NULL);
+ 	}
+ 	else
+@@ -372,7 +372,7 @@
+     elt = g_list_nth(list, 3);
+     item = GTK_CHECK_MENU_ITEM(elt->data);
+     g_signal_handlers_block_by_func(GTK_OBJECT(item), on_pc_log1_activate, NULL);
+-    gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.pclog));
++    gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.pclog));
+     g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_pc_log1_activate, NULL);
+ 
+     // stack
+@@ -381,7 +381,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_stack_frame1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.stack));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.stack));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_stack_frame1_activate, NULL);
+ 	}
+ 	else
+@@ -393,7 +393,7 @@
+ 	if(!options3.dbg_dock)
+ 	{
+ 		g_signal_handlers_block_by_func(GTK_OBJECT(item), on_heap_frame1_activate, NULL);
+-		gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.heap));
++		gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.heap));
+ 		g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_heap_frame1_activate, NULL);
+ 	}
+ 	else
+@@ -403,7 +403,7 @@
+ 	elt = g_list_nth(list, 6);
+     item = GTK_CHECK_MENU_ITEM(elt->data);
+     g_signal_handlers_block_by_func(GTK_OBJECT(item), on_ioports_frame1_activate, NULL);
+-    gtk_check_menu_item_set_active(item, GTK_WIDGET_VISIBLE(dbgw.iop));
++    gtk_check_menu_item_set_active(item, gtk_widget_get_visible(dbgw.iop));
+     g_signal_handlers_unblock_by_func(GTK_OBJECT(item), on_ioports_frame1_activate, NULL);
+ 
+ 	// dock/multi mode

--- a/tur/tiemu/0009-gui-debugger-dbg_dock-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0009-gui-debugger-dbg_dock-gtk_widget_get_visible.patch
@@ -1,0 +1,31 @@
+--- a/src/gui/debugger/dbg_dock.c	2008-05-26 12:48:30.000000000 -0400
++++ b/src/gui/debugger/dbg_dock.c	2026-07-30 19:37:28.894347313 -0400
+@@ -151,22 +151,22 @@
+ 
+ void dbgdock_show_all(int all)
+ {
+-	if(!GTK_WIDGET_VISIBLE(dbgw.dock) && all)
++	if(!gtk_widget_get_visible(dbgw.dock) && all)
+         gtk_widget_show(dbgw.dock);
+ 
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_window_iconify(GTK_WINDOW(dbgw.iop));
+-	if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++	if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_window_iconify(GTK_WINDOW(dbgw.pclog));
+ }
+ 
+ void dbgdock_hide_all(int all)
+ {
+-	if(GTK_WIDGET_VISIBLE(dbgw.dock) && all)
++	if(gtk_widget_get_visible(dbgw.dock) && all)
+         gtk_widget_hide(dbgw.dock);
+ 
+-    if(GTK_WIDGET_VISIBLE(dbgw.pclog))
++    if(gtk_widget_get_visible(dbgw.pclog))
+         gtk_widget_hide(dbgw.pclog);
+-	if(GTK_WIDGET_VISIBLE(dbgw.iop))
++	if(gtk_widget_get_visible(dbgw.iop))
+         gtk_widget_hide(dbgw.iop);
+ }

--- a/tur/tiemu/0010-gui-debugger-dbg_pkpts-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0010-gui-debugger-dbg_pkpts-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_bkpts.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_bkpts.c	2026-07-30 19:49:50.462347313 -0400
+@@ -388,7 +388,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(wnd));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.bkpts) && !options3.bkpts.closed)
++	if(!gtk_widget_get_visible(dbgw.bkpts) && !options3.bkpts.closed)
+ 		gtk_widget_show(wnd);
+ 
+ 	return wnd;

--- a/tur/tiemu/0011-gui-debugger-dbg_pclog-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0011-gui-debugger-dbg_pclog-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_pclog.c	2009-05-02 15:46:04.000000000 -0400
++++ /bsrc/gui/debugger/dbg_pclog.c	2026-07-30 20:46:46.690347313 -0400
+@@ -163,7 +163,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.pclog));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.pclog) && !options3.pclog.closed)
++	if(!gtk_widget_get_visible(dbgw.pclog) && !options3.pclog.closed)
+ 		gtk_widget_show(dbgw.pclog);
+ 
+ 	return dbgw.pclog;

--- a/tur/tiemu/0012-gui-debugger-dbg_stack-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0012-gui-debugger-dbg_stack-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_stack.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_stack.c	2026-07-30 20:50:27.506347313 -0400
+@@ -197,7 +197,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.stack));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.stack) && !options3.stack.closed)
++	if(!gtk_widget_get_visible(dbgw.stack) && !options3.stack.closed)
+ 		gtk_widget_show(dbgw.stack);
+ 
+ 	return dbgw.stack;

--- a/tur/tiemu/0013-gui-debugger-dbg_heap-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0013-gui-debugger-dbg_heap-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_heap.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_heap.c	2026-07-30 20:54:07.998347313 -0400
+@@ -171,7 +171,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.heap));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.heap) && !options3.heap.closed)
++	if(!gtk_widget_get_visible(dbgw.heap) && !options3.heap.closed)
+ 		gtk_widget_show(dbgw.heap);
+ 
+ 	return dbgw.heap;

--- a/tur/tiemu/0014-gui-debugger-dbg_code-gtk_widget_get_sensitive.patch
+++ b/tur/tiemu/0014-gui-debugger-dbg_code-gtk_widget_get_sensitive.patch
@@ -1,0 +1,20 @@
+--- a/src/gui/debugger/dbg_code.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_code.c	2026-08-12 21:43:25.077000000 -0400
+@@ -755,7 +755,7 @@
+ #ifdef __WIN32__
+ 	f = fopen("C:\\disasm.txt", "a+t");
+ #else
+-	f = fopen("/tmp/disasm.txt", "a+t");
++	f = fopen("@TERMUX_PREFIX@/tmp/disasm.txt", "a+t");
+ #endif
+ 	if(f == NULL)
+ 		return -1;
+@@ -1117,7 +1117,7 @@
+ 
+ int dbgcode_quit_enabled(void)
+ {
+-	return GTK_WIDGET_SENSITIVE(mi.m8);
++	return gtk_widget_get_sensitive(mi.m8);
+ }
+ 
+ static int close_debugger_wrapper(gpointer data)

--- a/tur/tiemu/0015-gui-debugger-dbg_iop-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0015-gui-debugger-dbg_iop-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_iop.c	2009-05-02 15:46:04.000000000 -0400
++++ b/src/gui/debugger/dbg_iop.c	2026-07-30 21:06:46.902347313 -0400
+@@ -455,7 +455,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.iop));
+ #endif
+     
+-	if(!GTK_WIDGET_VISIBLE(dbgw.iop) && !options3.iop.closed)
++	if(!gtk_widget_get_visible(dbgw.iop) && !options3.iop.closed)
+ 		gtk_widget_show(dbgw.iop);
+ 
+ 	return dbgw.iop;

--- a/tur/tiemu/0016-gui-debugger-dbg_regs-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0016-gui-debugger-dbg_regs-gtk_widget_get_visible.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_regs.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_regs.c	2026-07-30 21:10:58.518347313 -0400
+@@ -302,7 +302,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.regs));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.regs) && !options3.regs.closed)
++	if(!gtk_widget_get_visible(dbgw.regs) && !options3.regs.closed)
+ 		gtk_widget_show(dbgw.regs);
+ 
+ 	return dbgw.regs;

--- a/tur/tiemu/0017-gui-debugger-dbg_mem-gtk_widget_get_visible.patch
+++ b/tur/tiemu/0017-gui-debugger-dbg_mem-gtk_widget_get_visible.patch
@@ -1,0 +1,38 @@
+--- a/src/gui/debugger/dbg_mem.c	2009-05-06 15:48:47.000000000 -0400
++++ b/src/gui/debugger/dbg_mem.c	2026-07-30 21:47:45.010347313 -0400
+@@ -435,7 +435,7 @@
+ 		gtk_window_iconify(GTK_WINDOW(dbgw.mem));
+ #endif
+ 
+-	if(!GTK_WIDGET_VISIBLE(dbgw.mem) && !options3.mem.closed)
++	if(!gtk_widget_get_visible(dbgw.mem) && !options3.mem.closed)
+ 		gtk_widget_show(dbgw.mem);
+ 
+     return dbgw.mem;
+@@ -551,7 +551,7 @@
+ 
+ 	menu = gtk_menu_new();
+ 	g_object_set_data_full(G_OBJECT(menu), "memmap_menu",
+-			       gtk_widget_ref(menu),
++			       g_object_ref(menu),
+ 			       (GDestroyNotify)g_object_unref);
+ 
+ 	// (re)load mem map
+@@ -574,7 +574,7 @@
+ 
+ 		item = gtk_menu_item_new_with_label(label);
+ 		g_object_set_data_full(G_OBJECT(menu), "c_drive",
+-					   gtk_widget_ref(item),
++					   g_object_ref(item),
+ 					   (GDestroyNotify)g_object_unref);
+ 		gtk_widget_show(item);
+ 
+@@ -605,7 +605,7 @@
+ 
+ GLADE_CB void
+ on_notebook1_switch_page               (GtkNotebook     *notebook,
+-                                        GtkNotebookPage *page,
++                                        GtkNotebookTab  *page,
+                                         guint            page_num,
+                                         gpointer         user_data)
+ {

--- a/tur/tiemu/0018-gui-debugger-dbg_romcall-GTK_COMBO_BOX.patch
+++ b/tur/tiemu/0018-gui-debugger-dbg_romcall-GTK_COMBO_BOX.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/debugger/dbg_romcall.c	2007-07-05 07:36:10.000000000 -0400
++++ b/src/gui/debugger/dbg_romcall.c	2026-07-30 22:04:53.458347313 -0400
+@@ -163,7 +163,7 @@
+ 
+ 	// and set storage
+ 	gtk_combo_box_set_model(combo, model);
+-	gtk_combo_box_entry_set_text_column(GTK_COMBO_BOX_ENTRY(combo), COL_FULL);
++	gtk_combo_box_set_entry_text_column(GTK_COMBO_BOX(combo), COL_FULL);
+ 
+ 	/* --- */
+ 

--- a/tur/tiemu/0019-gui-logger-fix-implicit-int-for-logger-enabled.patch
+++ b/tur/tiemu/0019-gui-logger-fix-implicit-int-for-logger-enabled.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/logger/log_link.c	2009-05-02 15:46:04.000000000 -0400
++++ b/src/gui/logger/log_link.c	2026-07-30 22:09:59.246347313 -0400
+@@ -36,7 +36,7 @@
+ #include "filesel.h"
+ 
+ static GtkTextBuffer *txtbuf;
+-static logger_enabled = 0;
++static int logger_enabled = 0;
+ 
+ 
+ 

--- a/tur/tiemu/0020-dont-install-bundled-pedrom-tib-images.patch
+++ b/tur/tiemu/0020-dont-install-bundled-pedrom-tib-images.patch
@@ -1,0 +1,31 @@
+--- a/pedrom/Makefile.in	2009-04-30 16:45:57.000000000 -0400
++++ b/pedrom/Makefile.in	2026-08-01 13:14:45.594347313 -0400
+@@ -292,7 +292,7 @@
+ x_includes = @x_includes@
+ x_libraries = @x_libraries@
+ pedromdir = $(pkgdatadir)/pedrom
+-dist_pedrom_DATA = pedrom*.tib pedrom.txt
++dist_pedrom_DATA =
+ EXTRA_DIST = pedrom-src.tar.bz2
+ all: all-am
+ 
+@@ -482,7 +482,7 @@
+ 
+ 
+ uninstall:
+-	rm -f $(pkgdatadir)/pedrom/*.tib
++
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+ .NOEXPORT:
+--- a/pedrom/Makefile.am	2007-12-08 05:26:22.000000000 -0500
++++ b/pedrom/Makefile.am	2026-08-01 13:15:49.014347313 -0400
+@@ -1,7 +1,6 @@
+ pedromdir = $(pkgdatadir)/pedrom
+-dist_pedrom_DATA = pedrom*.tib pedrom.txt
++dist_pedrom_DATA = 
+ 
+ EXTRA_DIST = pedrom-src.tar.bz2
+ 
+ uninstall:
+-	rm -f $(pkgdatadir)/pedrom/*.tib

--- a/tur/tiemu/build.sh
+++ b/tur/tiemu/build.sh
@@ -1,0 +1,33 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tiemu/"
+TERMUX_PKG_DESCRIPTION="TiEmu is an emulator for TI89/TI89-Titanium/TI92/TI92+/V200PLT calculators. (no GDB)"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=3.03
+TERMUX_PKG_SRCURL="https://master.dl.sourceforge.net/project/gtktiemu/tiemu-linux/TIEmu%20${TERMUX_PKG_VERSION}/tiemu-${TERMUX_PKG_VERSION}-nogdb.tar.gz"
+TERMUX_PKG_SHA256=92d2830842278a8df29ab0717f5b89e06b34e88a50c073fe10ff9e6855b8a592
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_DEPENDS="glib, gtk2, libticables2, libticalcs2, libticonv, libtifiles2, libglade2, pedrom"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-sound
+--without-kde
+--disable-gdb
+"
+
+termux_step_create_debscripts() {
+		cat <<-EOF > ./postinst
+				#!$TERMUX_PREFIX/bin/sh
+				echo
+				echo "********"
+				echo "TiEmu is installed!"
+				echo
+				echo "By default it uses the open source PedroM OS for m68k-based TI calculators."
+				echo "You may also use a ROM dump of your own calculator, or a downloaded"
+				echo "upgrade ROM image from Texas Instruments."
+				echo
+				echo "It is unlawful to share or distribute your ROM image or an official image from"
+				echo "Texas Instruments as they are the property of Texas Instruments Inc."
+				echo "********"
+				echo
+		EOF
+}

--- a/tur/tilp2/0001-configure-remove-kde.patch
+++ b/tur/tilp2/0001-configure-remove-kde.patch
@@ -1,0 +1,39 @@
+--- a/configure.ac	2016-01-15 15:28:52.000000000 -0500
++++ b/configure.ac	2026-07-29 18:59:44.187235725 -0400
+@@ -130,9 +130,11 @@
+   esac
+ fi
+ if test "x$kde" = "xyes"; then
+-        AC_PROG_CXX
+-        AC_PATH_KDE
+-        AC_DEFINE(WITH_KDE, 1, [Use KDE support])
++        #AC_PROG_CXX
++        #AC_PATH_KDE
++        #AC_DEFINE(WITH_KDE, 1, [Use KDE support])
++		AC_MSG_WARN([KDE support requested but disabled in this build system])
++		kde=no
+ fi
+ AM_CONDITIONAL(USE_KDE, test "x$kde" = "xyes")
+ AC_SUBST(kde)
+--- a/src/Makefile.am	2016-03-14 15:55:57.000000000 -0400
++++ b/src/Makefile.am	2026-07-30 00:24:36.287235725 -0400
+@@ -9,17 +9,14 @@
+ tilp_CPPFLAGS = -I$(top_srcdir)/intl \
+ 	@TICABLES_CFLAGS@ @TIFILES_CFLAGS@ @TICALCS_CFLAGS@ @TICONV_CFLAGS@ \
+ 	@GLIB_CFLAGS@ @GTK_CFLAGS@ \
+-	@KDE_INCLUDES@ @QT_INCLUDES@ \
+ 	-DSHARE_DIR=\"$(pkgdatadir)\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
+ 	-DGTK_DISABLE_DEPRECATED
+ tilp_LDFLAGS = -export-dynamic
+ tilp_LDADD = @TICABLES_LIBS@ @TIFILES_LIBS@ @TICALCS_LIBS@ @TICONV_LIBS@ \
+-	@GLIB_LIBS@ @GTK_LIBS@ \
+-	@LIB_KDECORE@ @LIB_KDEUI@ @LIB_KIO@ @LIB_QT@ @KDE_LDFLAGS@ \
+-	@QT_LDFLAGS@ @X_LDFLAGS@ @LIBZ@
+-tilp_SOURCES = *.h \
++	@GLIB_LIBS@ @GTK_LIBS@ @LIBZ@
++tilp_SOURCES = \
+ 	tilp_calcs.c tilp_cmdline.c tilp_config.c tilp_error.c \
+ 	tilp_files.c tilp_gif.c tilp_main.c \
+ 	tilp_misc.c tilp_paths.c tilp_screen.c tilp_slct.c \

--- a/tur/tilp2/0002-device-reset.patch
+++ b/tur/tilp2/0002-device-reset.patch
@@ -1,0 +1,53 @@
+--- a/src/tilp_device.c	2016-03-14 16:26:36.000000000 -0400
++++ b/src/tilp_device.c	2026-08-20 15:10:58.222491036 -0400
+@@ -44,6 +44,7 @@
+ #define PAUSE(x) usleep(1000*(x))
+ #endif
+ 
++static int reset_in_progress = 0;
+ 
+ //----------------------------------------------------------------------------
+ 
+@@ -352,14 +353,34 @@
+ */
+ int tilp_device_reset(void)
+ {
+-	int ret = 0;
++        //static int reset_in_progress = 0;
++        int ret = 0;
+ 
+-	if (lk_open)
+-	{
+-		ret = ticables_cable_reset(cable_handle);
+-		tilp_device_err(ret);
+-		PAUSE(1000);
+-	}
++        if (!lk_open || reset_in_progress)
++                return 0;
+ 
+-	return ret;
++        reset_in_progress = 1;
++
++        tilp_info("tilp_device_reset: performing full close/open\n");
++
++        ret = tilp_device_close();
++
++        if (!ret)
++        {
++                PAUSE(1000);
++                ret = tilp_device_open();
++        }
++
++        tilp_info("tilp_device_reset: close/open returned %d\n", ret);
++
++        /*
++         * Do not call tilp_err() or tilp_device_err() here initially.
++         * tilp_device_close() / tilp_device_open() may already invoke
++         * error handling, and that could recurse back into this function.
++         */
++
++        reset_in_progress = 0;
++
++        return ret;
+ }
++

--- a/tur/tilp2/build.sh
+++ b/tur/tilp2/build.sh
@@ -1,0 +1,47 @@
+TERMUX_PKG_HOMEPAGE="http://lpg.ticalc.org/prj_tilp/"
+TERMUX_PKG_DESCRIPTION="TiLP is a linking program for Texas Instruments' graphing calculators."
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="3ls-it <3ls-it@pm.me>"
+TERMUX_PKG_VERSION=1.18
+TERMUX_PKG_SRCURL="https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-${TERMUX_PKG_VERSION}/tilp2-${TERMUX_PKG_VERSION}.tar.bz2"
+TERMUX_PKG_SHA256=7b3ab363eeb52504d6ef5811c5d264f8016060bb7bd427be5a064c2ed7384e47
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_DEPENDS="gettext, glib, gtk2, libticables2, libticalcs2, libticonv, libtifiles2, termux-api, zlib"
+
+termux_step_pre_configure() {
+		autoreconf -fi
+}
+
+termux_step_post_make_install() {
+		# We rename the binary as it needs a `termux-usb` wrapper
+		mv "$TERMUX_PREFIX/bin/tilp" "$TERMUX_PREFIX/bin/tilp.real"
+
+		# Install the wrapper script as `tilp`
+		install -Dm700 \
+				"$TERMUX_PKG_BUILDER_DIR/tilp" \
+				"$TERMUX_PREFIX/bin/tilp"
+}
+
+termux_step_create_debscripts() {
+		cat <<-EOF > ./postinst
+						#!$TERMUX_PREFIX/bin/sh
+						echo
+						echo "********"
+						echo "TiLP2 is now installed."
+						echo
+						echo "You will need to install the Termux:API app since the"
+						echo "launcher, 'tilp', uses 'termux-usb' as a wrapper to"
+						echo "give TiLP USB access to the GraphLink (SilverLink)"
+						echo "device/cable."
+						echo
+						echo "Known Limitations"
+						echo
+						echo "Currently there are two known limitations of this revision:"
+						echo "- ROM dumps create an unusable file,"
+						echo "- TiLP cannot connect with a TiEmu emulated device."
+						echo
+						echo "********"
+						echo
+		EOF
+}

--- a/tur/tilp2/tilp
+++ b/tur/tilp2/tilp
@@ -1,0 +1,46 @@
+#!/data/data/com.termux/files/usr/bin/sh
+# This script was installed as part of the `tilp2` package
+
+set -eu
+
+real="$PREFIX/bin/tilp.real"
+
+if [ ! -x "$real" ]; then
+    printf '%s\n' "tilp: real executable not found: $real" >&2
+    exit 1
+fi
+
+# Permit direct execution when already inside termux-usb.
+if [ -n "${TERMUX_USB_FD:-}" ]; then
+    exec "$real" "$@"
+fi
+
+# Optional explicit device override.
+if [ -n "${TILP_USB_DEVICE:-}" ]; then
+    device=$TILP_USB_DEVICE
+else
+    devices=$(
+        termux-usb -l |
+        grep -o '/dev/bus/usb/[0-9][0-9]*/[0-9][0-9]*' || :
+    )
+
+    count=$(printf '%s\n' "$devices" | sed '/^$/d' | wc -l)
+
+    case "$count" in
+        0)
+            printf '%s\n' "tilp: no USB devices found" >&2
+            exit 1
+            ;;
+        1)
+            device=$(printf '%s\n' "$devices" | sed -n '1p')
+            ;;
+        *)
+            printf '%s\n' \
+                "tilp: multiple USB devices found; set TILP_USB_DEVICE" >&2
+            printf '%s\n' "$devices" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+exec termux-usb -r -E -e "$real" "$device"


### PR DESCRIPTION
##### TI Utils
  
This PR adds the TI calculator utilities TiEmu and TiLP2 and their dependencies.

###### TiEmu v3.03  
  
TiEmu is an emulator for TI89/TI89-Titanium/TI92/TI92+/V200PLT calculators.  
  
- The upstream TiEmu 3.03 distribution includes legacy PedroM 0.81 `.tib` images, which are not compatible with the current TiEmu version. The current PedroM 0.83 distribution provides valid `.89u`/`.9xu` FLASH images, which are installed in TiEmu’s existing PedRom search directory. The interface of the PedroM OS is a Unix-like shell with familiar commands like: `ls`, `mkdir`, `cd`, etc.  
  
###### TiLP2 v1.18 
  
TiLP is a linking program for Texas Instruments' graphing calculators, which allows for moving files to and from the device, making backups, OS update/upgrades, screenshots, etc.
  
----

TI-89 Titanium emulation with TI AMS OS v3.10:  
  
<img width="439" height="981" alt="tiemu_ti89t_TiAMS" src="https://github.com/user-attachments/assets/9e1b939f-9a56-4761-8c68-e288ae052d5d" />  
   
  
TI-Voyage200 emulation with PedroM OS v0.83:  
  
<img width="1028" height="691" alt="tiemu_v200_PedroM83" src="https://github.com/user-attachments/assets/21ebde1e-9236-4e29-82ce-d4110c31fd16" />  
  
TiLP2 interface:  
<img width="1056" height="740" alt="tilp2" src="https://github.com/user-attachments/assets/df491758-b28c-473e-94d3-ddd134af6d58" />
