### PR TITLE
addpkg(tur/bun): 1.3.14

### DIFF
--- a/tur/bun/build.sh
+++ b/tur/bun/build.sh
@@ -1,0 +1,48 @@
+TERMUX_PKG_HOMEPAGE=https://bun.com
+TERMUX_PKG_DESCRIPTION="Incredibly fast JavaScript runtime, bundler, test runner, and package manager"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Gouranga Das Samrat <gouranga.das.khulna@gmail.com>"
+TERMUX_PKG_VERSION="1.3.14"
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=(
+	https://github.com/oven-sh/bun/releases/download/bun-v$TERMUX_PKG_VERSION/bun-linux-aarch64-android.zip
+	https://github.com/oven-sh/bun/releases/download/bun-v$TERMUX_PKG_VERSION/bun-linux-x64-android.zip
+)
+TERMUX_PKG_SHA256=(
+	992bcf239c91bedd873f8150cceef3db3b0618fa78161badd3c14dc6d24fe560
+	9ce0fccae24c55c5e59f6ee87c6defd8c79d0dc8a9ad2c214abd177c23c31d27
+)
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_EXCLUDED_ARCHES="arm,i686"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_post_get_source() {
+	curl -fsSL "https://raw.githubusercontent.com/oven-sh/bun/main/LICENSE.md" \
+		-o "$TERMUX_PKG_SRCDIR/LICENSE"
+}
+
+termux_step_make() {
+	: # prebuilt binary, nothing to build
+}
+
+termux_step_make_install() {
+	local _BUN_ARCH
+	case "$TERMUX_ARCH" in
+		aarch64) _BUN_ARCH=aarch64 ;;
+		x86_64)  _BUN_ARCH=x64 ;;
+	esac
+
+	# Whether the zip's top-level folder gets auto-stripped or not
+	# depends on extraction order/behavior, so check both possible
+	# locations instead of assuming one.
+	local _bun_bin
+	if [ -f "$TERMUX_PKG_SRCDIR/bun-linux-${_BUN_ARCH}-android/bun" ]; then
+		_bun_bin="$TERMUX_PKG_SRCDIR/bun-linux-${_BUN_ARCH}-android/bun"
+	elif [ -f "$TERMUX_PKG_SRCDIR/bun" ]; then
+		_bun_bin="$TERMUX_PKG_SRCDIR/bun"
+	else
+		termux_error_exit "Could not locate bun binary for $TERMUX_ARCH in $TERMUX_PKG_SRCDIR"
+	fi
+
+	install -Dm755 "$_bun_bin" "$TERMUX_PREFIX/bin/bun"
+}


### PR DESCRIPTION
Fixes termux/termux-packages#11188 #571 

### Description
This PR adds `bun` to Termux using official prebuilt Android binaries introduced in Bun v1.3.14.

### Details
- **Official Support:** Upstream Bun now natively supports Android (`aarch64` and `x86_64`).
- **Binary Details:** Prebuilt binaries are Position-Independent Executables (PIE) linked directly against standard Bionic libraries (`libc.so`, `libm.so`, `libdl.so`), making them compatible with Termux without needing glibc wrappers.
- **Architecture Limits:** Restricted to `aarch64` and `x86_64` as upstream only provides Android builds for these architectures.

Upstream's release blog: [freebsd-and-android-support](https://bun.com/blog/bun-v1.3.14#freebsd-and-android-support) 

Note: Migrated from termux/termux-packages#31115 due to main repo build policies.