### PR TITLE
dosemu2: de-duplicate deps

### DIFF
--- a/tur/dosemu2/build.sh
+++ b/tur/dosemu2/build.sh
@@ -3,12 +3,11 @@ TERMUX_PKG_DESCRIPTION="Run DOS programs under linux."
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@stsp"
 TERMUX_PKG_VERSION="2.0pre9-git"
-TERMUX_PKG_REVISION=9
+TERMUX_PKG_REVISION=10
 TERMUX_PKG_SRCURL=git+https://github.com/dosemu2/dosemu2
 TERMUX_PKG_GIT_BRANCH=devel
 _COMMIT=82770aba398485117c56523a1a5c261f6e37ca64
 TERMUX_PKG_SHA256=6ae390a22f2e50600937b21172568a11df35c04440002ffbb0554b76bbdbfe58
-TERMUX_PKG_BUILD_DEPENDS="libandroid-posix-semaphore, libandroid-glob, slang, libao, fluidsynth, ladspa-sdk, libslirp, readline, json-c, libseccomp, libsearpc, sdl3, sdl3-ttf, fontconfig, fdpp, dj64dev"
 TERMUX_PKG_DEPENDS="comcom64, instfd, libandroid-posix-semaphore, libandroid-glob, slang, libao, fluidsynth, ladspa-sdk, libslirp, readline, json-c, libseccomp, libsearpc, sdl3, sdl3-ttf, fontconfig, fdpp, dj64dev"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 --disable-landlock


### PR DESCRIPTION
TERMUX_PKG_BUILD_DEPENDS was mirroring TERMUX_PKG_DEPENDS. As this is unnecessary, let's remove.