### PR TITLE
fix(common-files/building-system-patches/disable-apparmor): update 0008-disable-apparmor.patch for termux-packages changes

### DIFF
--- a/common-files/building-system-patches/0008-disable-apparmor.patch
+++ b/common-files/building-system-patches/0008-disable-apparmor.patch
@@ -9,7 +9,7 @@
  		fuse-overlayfs \
  			"${TERMUX_STANDALONE_TOOLCHAIN}" \
  			-o lowerdir="${NDK}/toolchains/llvm/prebuilt/linux-x86_64" \
-@@ -145,12 +145,17 @@ termux_setup_toolchain_29() {
+@@ -145,12 +145,15 @@ termux_setup_toolchain_29() {
  		return
  	fi
  
@@ -22,11 +22,9 @@
  		_NDK_ARCHNAME=x86
  	fi
 +	cp "$NDK/toolchains/llvm/prebuilt/linux-x86_64" "${TERMUX_STANDALONE_TOOLCHAIN}" -r
-+	cp "$NDK/source.properties" "${TERMUX_STANDALONE_TOOLCHAIN}"
-+
+ 	cp $NDK/source.properties $TERMUX_STANDALONE_TOOLCHAIN/
  	# Remove android-support header wrapping not needed on android-21:
  	rm -Rf $TERMUX_STANDALONE_TOOLCHAIN/sysroot/usr/local
- 
 --- a/scripts/run-docker.sh
 +++ b/scripts/run-docker.sh
 @@ -92,7 +92,7 @@ if [ "$UNAME" = Darwin ]; then


### PR DESCRIPTION
Upstream `termux/termux-packages` commit `e6ab7536eb` (`bump(swift): 6.2.1 to 6.2.4`) added `cp $NDK/source.properties $TERMUX_STANDALONE_TOOLCHAIN/` to `scripts/build/toolchain/termux_setup_toolchain_29.sh`.

This caused hunk #2 of `0008-disable-apparmor.patch` to fail during `./setup-environment.sh`, breaking all TUR CI runs:
```
Applying patch: ./common-files/building-system-patches/0008-disable-apparmor.patch
1 out of 2 hunks FAILED -- saving rejects to file scripts/build/toolchain/termux_setup_toolchain_29.sh.rej
##[error]Process completed with exit code 1.
```

This PR removes the duplicate copy line in the patch so that it matches current upstream `termux-packages`.